### PR TITLE
Everything except texts_in_widgets.md is reworked for iced version 0.12.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 This tutorial serves as a quick start for the library.
 We try to keep each part of the tutorial as simple as possible.
 
-(Currently, this tutorial is for version `0.10.0`.)
+(Currently, this tutorial is for version `0.12.1`.)
 
 Contents:
 

--- a/tutorial/adding_widgets.md
+++ b/tutorial/adding_widgets.md
@@ -1,6 +1,6 @@
 # Adding Widgets
 
-Use [column!](https://docs.iced.rs/iced/widget/macro.column.html) and [row!](https://docs.iced.rs/iced/widget/macro.row.html) to group multiple widgets such as [text](https://docs.iced.rs/iced/widget/fn.text.html) and [button](https://docs.iced.rs/iced/widget/fn.button.html).
+Use [column!](https://docs.rs/iced/0.12.1/iced/widget/macro.column.html) and [row!](https://docs.rs/iced/0.12.1/iced/widget/macro.row.html) to group multiple widgets such as [text](https://docs.rs/iced/0.12.1/iced/widget/fn.text.html) and [button](https://docs.rs/iced/0.12.1/iced/widget/fn.button.html).
 
 ```rust
 use iced::{

--- a/tutorial/batch_subscriptions.md
+++ b/tutorial/batch_subscriptions.md
@@ -1,17 +1,16 @@
 # Batch Subscriptions
 
 This tutorial follows from the previous two tutorials ([keyboard events](./producing_messages_by_keyboard_events.md) and [timers](./producing_messages_by_timers.md)).
-We combine the two [Subscriptions](https://docs.iced.rs/iced/subscription/struct.Subscription.html) of keyboard events and timers.
-This is done by [Subscription::batch](https://docs.iced.rs/iced/subscription/struct.Subscription.html#method.batch) function.
+We combine the two [Subscriptions](https://docs.rs/iced/0.12.1/iced/subscription/struct.Subscription.html) of keyboard events and timers.
+This is done by [Subscription::batch](https://docs.rs/iced/0.12.1/iced/subscription/struct.Subscription.html#method.batch) function.
 
 In the following app, press the space key to start or stop the timer.
 
 ```rust
 use iced::{
-    event::Status,
+    event::{self, Status},
     executor,
-    keyboard::KeyCode,
-    subscription,
+    keyboard::{key::Named, Key},
     time::{self, Duration},
     widget::text,
     Application, Command, Event, Settings, Subscription,
@@ -60,22 +59,22 @@ impl Application for MyApp {
         Command::none()
     }
 
-    fn view(&self) -> iced::Element<'_, Self::Message, iced::Renderer<Self::Theme>> {
+    fn view(&self) -> iced::Element<'_, Self::Message> {
         text(self.seconds).into()
     }
 
     fn subscription(&self) -> iced::Subscription<Self::Message> {
-        let subscr_key = subscription::events_with(|event, status| match (event, status) {
+        let subscr_key = event::listen_with(|event, status| match (event, status) {
             (
                 Event::Keyboard(iced::keyboard::Event::KeyPressed {
-                    key_code: KeyCode::Space,
+                    key: Key::Named(Named::Space),
                     ..
                 }),
                 Status::Ignored,
             ) => Some(MyAppMessage::StartOrStop),
             _ => None,
         });
-        
+
         if self.running {
             Subscription::batch(vec![
                 subscr_key,

--- a/tutorial/button.md
+++ b/tutorial/button.md
@@ -1,8 +1,8 @@
 # Button
 
-The [Button](https://docs.iced.rs/iced/widget/button/struct.Button.html) widget supports reactions to pressing/touching events.
+The [Button](https://docs.rs/iced/0.12.1/iced/widget/button/struct.Button.html) widget supports reactions to pressing/touching events.
 It has two methods of constructions.
-If the method [on_press](https://docs.iced.rs/iced/widget/button/struct.Button.html#method.on_press) is set, the button is enabled, and is disabled otherwise.
+If the method [on_press](https://docs.rs/iced/0.12.1/iced/widget/button/struct.Button.html#method.on_press) is set, the button is enabled, and is disabled otherwise.
 We can also set padding around the text of the button.
 
 ```rust

--- a/tutorial/changing_displaying_content.md
+++ b/tutorial/changing_displaying_content.md
@@ -1,11 +1,11 @@
 # Changing Displaying Content
 
-To change the content in [view](https://docs.iced.rs/iced/trait.Sandbox.html#tymethod.view) dynamically, we can do the following:
+To change the content in [view](https://docs.rs/iced/0.12.1/iced/trait.Sandbox.html#tymethod.view) dynamically, we can do the following:
 
 * Add some fields (e.g., `counter`) to the main struct `MyApp`.
-* Display the fields in [view](https://docs.iced.rs/iced/trait.Sandbox.html#tymethod.view) (e.g., `text(self.counter)`).
-* Produce some messages in [view](https://docs.iced.rs/iced/trait.Sandbox.html#tymethod.view) (e.g., `button(...).on_press(MyAppMessage::ButtonPressed)`).
-* Update the fields when messages are received in [update](https://docs.iced.rs/iced/trait.Sandbox.html#tymethod.update) (e.g., `self.counter += 1`).
+* Display the fields in [view](https://docs.rs/iced/0.12.1/iced/trait.Sandbox.html#tymethod.view) (e.g., `text(self.counter)`).
+* Produce some messages in [view](https://docs.rs/iced/0.12.1/iced/trait.Sandbox.html#tymethod.view) (e.g., `button(...).on_press(MyAppMessage::ButtonPressed)`).
+* Update the fields when messages are received in [update](https://docs.rs/iced/0.12.1/iced/trait.Sandbox.html#tymethod.update) (e.g., `self.counter += 1`).
 
 ```rust
 use iced::{

--- a/tutorial/changing_styles.md
+++ b/tutorial/changing_styles.md
@@ -1,10 +1,10 @@
 # Changing Styles
 
 Most widgets support `style` method to change their styles.
-These methods take parameters from [enums](https://doc.rust-lang.org/std/keyword.enum.html) of [theme](https://docs.iced.rs/iced/theme/index.html) module.
-For example, [widget::Text](https://docs.iced.rs/iced/widget/type.Text.html) takes [theme::Text](https://docs.iced.rs/iced/theme/enum.Text.html) as the parameter of its [style](https://docs.iced.rs/iced/advanced/widget/struct.Text.html#method.style) method, and [widget::Button](https://docs.iced.rs/iced/widget/struct.Button.html) takes [theme::Button](https://docs.iced.rs/iced/theme/enum.Button.html) as the parameter of its [style](https://docs.iced.rs/iced/widget/struct.Button.html#method.style) method.
+These methods take parameters from [enums](https://doc.rust-lang.org/std/keyword.enum.html) of [theme](https://docs.rs/iced/0.12.1/iced/theme/index.html) module.
+For example, [widget::Text](https://docs.rs/iced/0.12.1/iced/widget/type.Text.html) takes [theme::Text](https://docs.rs/iced/0.12.1/iced/theme/enum.Text.html) as the parameter of its [style](https://docs.rs/iced/0.12.1/iced/advanced/widget/struct.Text.html#method.style) method, and [widget::Button](https://docs.rs/iced/0.12.1/iced/widget/struct.Button.html) takes [theme::Button](https://docs.rs/iced/0.12.1/iced/theme/enum.Button.html) as the parameter of its [style](https://docs.rs/iced/0.12.1/iced/widget/struct.Button.html#method.style) method.
 
-Since [theme::Text](https://docs.iced.rs/iced/theme/enum.Text.html) implements [From\<Color>](https://docs.iced.rs/iced/theme/enum.Text.html#impl-From%3CColor%3E-for-Text), we can also use [Color](https://docs.iced.rs/iced/struct.Color.html) struct directly for the [style](https://docs.iced.rs/iced/advanced/widget/struct.Text.html#method.style) method of [widget::Text](https://docs.iced.rs/iced/widget/type.Text.html).
+Since [theme::Text](https://docs.rs/iced/0.12.1/iced/theme/enum.Text.html) implements [From\<Color>](https://docs.rs/iced/0.12.1/iced/theme/enum.Text.html#impl-From%3CColor%3E-for-Text), we can also use [Color](https://docs.rs/iced/0.12.1/iced/struct.Color.html) struct directly for the [style](https://docs.rs/iced/0.12.1/iced/advanced/widget/struct.Text.html#method.style) method of [widget::Text](https://docs.rs/iced/0.12.1/iced/widget/type.Text.html).
 
 ```rust
 use iced::{

--- a/tutorial/changing_the_window_dynamically.md
+++ b/tutorial/changing_the_window_dynamically.md
@@ -1,11 +1,11 @@
 # Changing The Window Dynamically
 
-We can use functions provided in [window](https://docs.iced.rs/iced/window/index.html) module to change the window after it is initialized.
-For example, to [resize](https://docs.iced.rs/iced/window/fn.resize.html) the window.
-These functions return [Command](https://docs.iced.rs/iced/struct.Command.html), which can be used as the return value in [update](https://docs.iced.rs/iced/application/trait.Application.html#tymethod.update) method.
-Developers might be interested in other [Commands](https://docs.iced.rs/iced/struct.Command.html) in [window](https://docs.iced.rs/iced/window/index.html) module.
+We can use functions provided in [window](https://docs.rs/iced/0.12.1/iced/window/index.html) module to change the window after it is initialized.
+For example, to [resize](https://docs.rs/iced/0.12.1/iced/window/fn.resize.html) the window.
+These functions return [Command](https://docs.rs/iced/0.12.1/iced/struct.Command.html), which can be used as the return value in [update](https://docs.rs/iced/0.12.1/iced/application/trait.Application.html#tymethod.update) method.
+Developers might be interested in other [Commands](https://docs.rs/iced/0.12.1/iced/struct.Command.html) in [window](https://docs.rs/iced/0.12.1/iced/window/index.html) module.
 
-Note: If you find [resize](https://docs.iced.rs/iced/window/fn.resize.html) needs an [Id](https://docs.iced.rs/iced/window/struct.Id.html), you can get it by [fetch_id](https://docs.iced.rs/iced/window/fn.fetch_id.html).
+Note: If you find [resize](https://docs.rs/iced/0.12.1/iced/window/fn.resize.html) needs an [Id](https://docs.rs/iced/0.12.1/iced/window/struct.Id.html), you can get it by [fetch_id](https://docs.rs/iced/0.12.1/iced/window/fn.fetch_id.html).
 
 ```rust
 use iced::{
@@ -64,7 +64,7 @@ impl Application for MyApp {
         Command::none()
     }
 
-    fn view(&self) -> iced::Element<'_, Self::Message, iced::Renderer<Self::Theme>> {
+    fn view(&self) -> iced::Element<'_, Self::Message> {
         row![
             text_input("Width", &self.width).on_input(MyAppMessage::UpdateWidth),
             text_input("Height", &self.height).on_input(MyAppMessage::UpdateHeight),

--- a/tutorial/changing_themes.md
+++ b/tutorial/changing_themes.md
@@ -1,6 +1,6 @@
 # Changing Themes
 
-We can implement [theme](https://docs.iced.rs/iced/trait.Sandbox.html#method.theme) method in [Sandbox](https://docs.iced.rs/iced/trait.Sandbox.html) to return the desired theme.
+We can implement [theme](https://docs.rs/iced/0.12.1/iced/trait.Sandbox.html#method.theme) method in [Sandbox](https://docs.rs/iced/0.12.1/iced/trait.Sandbox.html) to return the desired theme.
 
 ```rust
 use iced::{Sandbox, Settings};

--- a/tutorial/checkbox.md
+++ b/tutorial/checkbox.md
@@ -1,6 +1,6 @@
 # Checkbox
 
-The [Checkbox](https://docs.iced.rs/iced/widget/checkbox/struct.Checkbox.html) widget represents a boolean value.
+The [Checkbox](https://docs.rs/iced/0.12.1/iced/widget/checkbox/struct.Checkbox.html) widget represents a boolean value.
 It has two methods of constructions.
 It supports reactions to clicking and touching.
 It is able to change styles of the box and the text.
@@ -52,27 +52,27 @@ impl Sandbox for MyApp {
 
     fn view(&self) -> iced::Element<'_, Self::Message> {
         column![
-            Checkbox::new("Construct from struct", false, |_| MyAppMessage::DoNothing),
-            checkbox("Construct from function", false, |_| {
+            Checkbox::new("Construct from struct", false).on_toggle(|_| MyAppMessage::DoNothing),
+            checkbox("Construct from function", false).on_toggle(|_| {
                 MyAppMessage::DoNothing
             }),
-            checkbox("Functional checkbox", self.checkbox3, |b| MyAppMessage::Update3(b)),
-            checkbox("Shorter parameter", self.checkbox4, MyAppMessage::Update4),
-            checkbox("Larger box", false, |_| MyAppMessage::DoNothing).size(30),
-            checkbox("Different icon", true, |_| MyAppMessage::DoNothing).icon(Icon {
+            checkbox("Functional checkbox", self.checkbox3).on_toggle(|b| MyAppMessage::Update3(b)),
+            checkbox("Shorter parameter", self.checkbox4).on_toggle(MyAppMessage::Update4),
+            checkbox("Larger box", false).on_toggle(|_| MyAppMessage::DoNothing).size(30),
+            checkbox("Different icon", true).on_toggle(|_| MyAppMessage::DoNothing).icon(Icon {
                 font: Font::DEFAULT,
                 code_point: '*',
                 size: None,
                 line_height: LineHeight::default(),
                 shaping: Shaping::default()
             }),
-            checkbox("Different font", false, |_| MyAppMessage::DoNothing).font(Font {
+            checkbox("Different font", false).on_toggle(|_| MyAppMessage::DoNothing).font(Font {
                 family: Family::Fantasy,
                 ..Font::DEFAULT
             }),
-            checkbox("Larger text", false, |_| MyAppMessage::DoNothing).text_size(24),
-            checkbox("Special character 😊", false, |_| MyAppMessage::DoNothing).text_shaping(Shaping::Advanced),
-            checkbox("Space between box and text", false, |_| MyAppMessage::DoNothing).spacing(30),
+            checkbox("Larger text", false).on_toggle(|_| MyAppMessage::DoNothing).text_size(24),
+            checkbox("Special character 😊", false).on_toggle(|_| MyAppMessage::DoNothing).text_shaping(Shaping::Advanced),
+            checkbox("Space between box and text", false).on_toggle(|_| MyAppMessage::DoNothing).spacing(30),
         ]
         .into()
     }

--- a/tutorial/closing_the_window_on_demand.md
+++ b/tutorial/closing_the_window_on_demand.md
@@ -1,10 +1,10 @@
 # Closing The Window On Demand
 
 This tutorial follows the [previous tutorial](./changing_the_window_dynamically.md).
-We use the [close](https://docs.iced.rs/iced/window/fn.close.html) function in [window](https://docs.iced.rs/iced/window/index.html) module to close the window.
-This is also done by returning the [Command](https://docs.iced.rs/iced/struct.Command.html) obtained by [close](https://docs.iced.rs/iced/window/fn.close.html) function.
+We use the [close](https://docs.rs/iced/0.12.1/iced/window/fn.close.html) function in [window](https://docs.rs/iced/0.12.1/iced/window/index.html) module to close the window.
+This is also done by returning the [Command](https://docs.rs/iced/0.12.1/iced/struct.Command.html) obtained by [close](https://docs.rs/iced/0.12.1/iced/window/fn.close.html) function.
 
-Note: If you find the function needs an [Id](https://docs.iced.rs/iced/window/struct.Id.html), you can get it by [fetch_id](https://docs.iced.rs/iced/window/fn.fetch_id.html).
+Note: If you find the function needs an [Id](https://docs.rs/iced/0.12.1/iced/window/struct.Id.html), you can get it by [fetch_id](https://docs.rs/iced/0.12.1/iced/window/fn.fetch_id.html).
 
 ```rust
 use iced::{
@@ -41,6 +41,7 @@ impl Application for MyApp {
     fn update(&mut self, message: Self::Message) -> iced::Command<Self::Message> {
         match message {
             MyAppMessage::CloseWindow => window::close(),
+			// MyAppMessage::CloseWindow => window::close(window::Id::MAIN),
         }
     }
 

--- a/tutorial/column.md
+++ b/tutorial/column.md
@@ -1,6 +1,6 @@
 # Column
 
-[Column](https://docs.rs/iced/latest/iced/widget/struct.Column.html) helps us placing widgets vertically.
+[Column](https://docs.rs/iced/0.12.1/iced/widget/struct.Column.html) helps us placing widgets vertically.
 It can leave some space between its boundary and its inner content.
 It can also add spaces among its inner widgets.
 The inner widgets can be aligned left, middle or right.

--- a/tutorial/combobox.md
+++ b/tutorial/combobox.md
@@ -1,6 +1,6 @@
 # ComboBox
 
-The [ComboBox](https://docs.iced.rs/iced/widget/combo_box/struct.ComboBox.html) widget represents a choice among multiple values.
+The [ComboBox](https://docs.rs/iced/0.12.1/iced/widget/combo_box/struct.ComboBox.html) widget represents a choice among multiple values.
 The values are shown in a dropdown menu and is searchable.
 The widget has two methods of constructions.
 It supports reactions to keyboard inputs and mouse selections.

--- a/tutorial/container.md
+++ b/tutorial/container.md
@@ -1,7 +1,7 @@
 # Container
 
-[Container](https://docs.rs/iced/latest/iced/widget/container/struct.Container.html) is another way to help us laying out widgets, especially when we need to algin a widget center both horizontally and vertically.
-[Container](https://docs.rs/iced/latest/iced/widget/container/struct.Container.html) accepts any widget including [Column](https://docs.rs/iced/latest/iced/widget/struct.Column.html) and [Row](https://docs.rs/iced/latest/iced/widget/struct.Row.html).
+[Container](https://docs.rs/iced/0.12.1/iced/widget/container/struct.Container.html) is another way to help us laying out widgets, especially when we need to algin a widget center both horizontally and vertically.
+[Container](https://docs.rs/iced/0.12.1/iced/widget/container/struct.Container.html) accepts any widget including [Column](https://docs.rs/iced/0.12.1/iced/widget/struct.Column.html) and [Row](https://docs.rs/iced/0.12.1/iced/widget/struct.Row.html).
 
 ```rust
 use iced::{

--- a/tutorial/controlling_widgets_by_commands.md
+++ b/tutorial/controlling_widgets_by_commands.md
@@ -1,11 +1,11 @@
 # Controlling Widgets By Commands
 
-We can use [Command](https://docs.iced.rs/iced/struct.Command.html) to control widgets.
+We can use [Command](https://docs.rs/iced/0.12.1/iced/struct.Command.html) to control widgets.
 Some widgets have [functions](https://doc.rust-lang.org/stable/book/ch03-03-how-functions-work.html) to change their behavior.
 These [functions](https://doc.rust-lang.org/stable/book/ch03-03-how-functions-work.html) are located at their respective modules.
-For example, [focus](https://docs.iced.rs/iced/widget/text_input/fn.focus.html) is a function in [text_input](https://docs.iced.rs/iced/widget/text_input/index.html) module that makes a [TextInput](https://docs.iced.rs/iced/widget/text_input/struct.TextInput.html) gaining the focus.
-This function takes a parameter [text_input::Id](https://docs.iced.rs/iced/widget/text_input/struct.Id.html), which can be specified by [id](https://docs.iced.rs/iced/widget/text_input/struct.TextInput.html#method.id) method of [TextInput](https://docs.iced.rs/iced/widget/text_input/struct.TextInput.html).
-The function returns a [Command](https://docs.iced.rs/iced/struct.Command.html) and we can return the [Command](https://docs.iced.rs/iced/struct.Command.html) in [update](https://docs.iced.rs/iced/application/trait.Application.html#tymethod.update) or [new](https://docs.iced.rs/iced/application/trait.Application.html#tymethod.new) methods of [Application](https://docs.iced.rs/iced/application/trait.Application.html).
+For example, [focus](https://docs.rs/iced/0.12.1/iced/widget/text_input/fn.focus.html) is a function in [text_input](https://docs.rs/iced/0.12.1/iced/widget/text_input/index.html) module that makes a [TextInput](https://docs.rs/iced/0.12.1/iced/widget/text_input/struct.TextInput.html) gaining the focus.
+This function takes a parameter [text_input::Id](https://docs.rs/iced/0.12.1/iced/widget/text_input/struct.Id.html), which can be specified by [id](https://docs.rs/iced/0.12.1/iced/widget/text_input/struct.TextInput.html#method.id) method of [TextInput](https://docs.rs/iced/0.12.1/iced/widget/text_input/struct.TextInput.html).
+The function returns a [Command](https://docs.rs/iced/0.12.1/iced/struct.Command.html) and we can return the [Command](https://docs.rs/iced/0.12.1/iced/struct.Command.html) in [update](https://docs.rs/iced/0.12.1/iced.rs/iced/application/trait.Application.html#tymethod.update) or [new](https://docs.rs/iced/0.12.1/iced/application/trait.Application.html#tymethod.new) methods of [Application](https://docs.rs/iced/0.12.1/iced/application/trait.Application.html).
 
 ```rust
 use iced::{
@@ -57,7 +57,7 @@ impl Application for MyApp {
         Command::none()
     }
 
-    fn view(&self) -> iced::Element<'_, Self::Message, iced::Renderer<Self::Theme>> {
+    fn view(&self) -> iced::Element<'_, Self::Message> {
         column![
             button("Edit text").on_press(MyAppMessage::EditText),
             text_input("", &self.some_text)

--- a/tutorial/custom_background.md
+++ b/tutorial/custom_background.md
@@ -1,12 +1,12 @@
 # Custom Background
 
-We can also draw an image on a [Widget](https://docs.rs/iced/latest/iced/advanced/widget/trait.Widget.html).
+We can also draw an image on a [Widget](https://docs.rs/iced/0.12.1/iced/advanced/widget/trait.Widget.html).
 
-Similar to the [Image](https://docs.rs/iced/latest/iced/widget/image/struct.Image.html) widget, we have to enable the [image](https://docs.rs/crate/iced/latest/features#image) feature.
+Similar to the [Image](https://docs.rs/iced/0.12.1/iced/widget/image/struct.Image.html) widget, we have to enable the [image](https://docs.rs/crate/iced/latest/features#image) feature.
 
 ```toml
 [dependencies]
-iced = { version = "0.10.0", features = ["image", "advanced"] }
+iced = { version = "0.12.1", features = ["image", "advanced"] }
 ```
 
 Assume we have an image, named `ferris.png`,  in the Cargo root directory.
@@ -26,10 +26,10 @@ impl MyWidgetWithImage {
 }
 ```
 
-Then, we use the [iced::widget::image::layout](https://docs.rs/iced/latest/iced/widget/image/fn.layout.html) function to determine the [layout](https://docs.rs/iced/latest/iced/advanced/widget/trait.Widget.html#tymethod.layout) of our widget.
+Then, we use the [iced::widget::image::layout](https://docs.rs/iced/0.12.1/iced/widget/image/fn.layout.html) function to determine the [layout](https://docs.rs/iced/0.12.1/iced/advanced/widget/trait.Widget.html#tymethod.layout) of our widget.
 
 ```rust
-fn layout(&self, renderer: &Renderer, limits: &layout::Limits) -> layout::Node {
+fn layout(&self, _tree: &mut Tree, renderer: &Renderer, limits: &layout::Limits) -> layout::Node {
     iced::widget::image::layout(
         renderer,
         limits,
@@ -41,7 +41,7 @@ fn layout(&self, renderer: &Renderer, limits: &layout::Limits) -> layout::Node {
 }
 ```
 
-And we draw the image by the [iced::widget::image::draw](https://docs.rs/iced/latest/iced/widget/image/fn.draw.html) function.
+And we draw the image by the [iced::widget::image::draw](https://docs.rs/iced/0.12.1/iced/widget/image/fn.draw.html) function.
 
 ```rust
 fn draw(
@@ -55,23 +55,33 @@ fn draw(
     _viewport: &Rectangle,
 ) {
     renderer.fill_quad(
-        Quad {
-            bounds: layout.bounds(),
-            border_radius: 10.0.into(),
-            border_width: 1.0,
-            border_color: Color::from_rgb(1.0, 0.66, 0.6),
-        },
-        Color::BLACK,
+		Quad {
+			bounds: layout.bounds(),
+			border: Border {
+				color: Color::from_rgb(1.0, 0.66, 0.6),
+				width: 1.0,
+				radius: 10.0.into(),
+			},
+			shadow: Shadow::default(),
+		},
+		Color::BLACK,
     );
+	
+	iced::widget::image::draw(
+		renderer,
+		layout,
+		&self.handle,
+		iced::ContentFit::Contain,
+		iced::widget::image::FilterMethod::Linear,
+	);
 
-    iced::widget::image::draw(renderer, layout, &self.handle, iced::ContentFit::Contain);
 }
 ```
 
-Both functions require the `Renderer` to implement [iced::advanced::image::Renderer](https://docs.rs/iced/latest/iced/advanced/image/trait.Renderer.html).
+Both functions require the `Renderer` to implement [iced::advanced::image::Renderer](https://docs.rs/iced/0.12.1/iced/advanced/image/trait.Renderer.html).
 
 ```rust
-impl<Message, Renderer> Widget<Message, Renderer> for MyWidgetWithImage
+impl<Message, Renderer> Widget<Message, Theme, Renderer> for MyWidgetWithImage
 where
     Renderer: iced::advanced::Renderer + iced::advanced::image::Renderer<Handle = Handle>,
 ```
@@ -86,8 +96,8 @@ use iced::{
         widget::Tree,
         Layout, Widget,
     },
-    widget::{container, image::Handle},
-    Color, Element, Length, Rectangle, Sandbox, Settings,
+    widget::{container, image::Handle, Theme},
+    Border, Color, Element, Length, Rectangle, Sandbox, Settings, Shadow, Size,
 };
 
 fn main() -> iced::Result {
@@ -131,19 +141,23 @@ impl MyWidgetWithImage {
     }
 }
 
-impl<Message, Renderer> Widget<Message, Renderer> for MyWidgetWithImage
+impl<Message, Renderer> Widget<Message, Theme, Renderer> for MyWidgetWithImage
 where
     Renderer: iced::advanced::Renderer + iced::advanced::image::Renderer<Handle = Handle>,
 {
-    fn width(&self) -> Length {
-        Length::Shrink
+    fn size(&self) -> Size<Length> {
+        Size {
+            width: Length::Shrink,
+            height: Length::Shrink,
+        }
     }
 
-    fn height(&self) -> Length {
-        Length::Shrink
-    }
-
-    fn layout(&self, renderer: &Renderer, limits: &layout::Limits) -> layout::Node {
+    fn layout(
+        &self,
+        _tree: &mut Tree,
+        renderer: &Renderer,
+        limits: &layout::Limits,
+    ) -> layout::Node {
         iced::widget::image::layout(
             renderer,
             limits,
@@ -158,7 +172,7 @@ where
         &self,
         _state: &Tree,
         renderer: &mut Renderer,
-        _theme: &Renderer::Theme,
+        _theme: &Theme,
         _style: &renderer::Style,
         layout: Layout<'_>,
         _cursor: mouse::Cursor,
@@ -167,18 +181,27 @@ where
         renderer.fill_quad(
             Quad {
                 bounds: layout.bounds(),
-                border_radius: 10.0.into(),
-                border_width: 1.0,
-                border_color: Color::from_rgb(1.0, 0.66, 0.6),
+                border: Border {
+                    color: Color::from_rgb(1.0, 0.66, 0.6),
+                    width: 1.0,
+                    radius: 10.0.into(),
+                },
+                shadow: Shadow::default(),
             },
             Color::BLACK,
         );
 
-        iced::widget::image::draw(renderer, layout, &self.handle, iced::ContentFit::Contain);
+        iced::widget::image::draw(
+            renderer,
+            layout,
+            &self.handle,
+            iced::ContentFit::Contain,
+            iced::widget::image::FilterMethod::Linear,
+        );
     }
 }
 
-impl<'a, Message, Renderer> From<MyWidgetWithImage> for Element<'a, Message, Renderer>
+impl<'a, Message, Renderer> From<MyWidgetWithImage> for Element<'a, Message, Theme, Renderer>
 where
     Renderer: iced::advanced::Renderer + iced::advanced::image::Renderer<Handle = Handle>,
 {

--- a/tutorial/custom_styles.md
+++ b/tutorial/custom_styles.md
@@ -1,13 +1,13 @@
 # Custom Styles
 
-We mentioned in the [previous tutorial](./changing_styles.md) about how to change styles of widgets by the [enums](https://doc.rust-lang.org/std/keyword.enum.html) in [theme](https://docs.iced.rs/iced/theme/index.html) module.
-Most [enums](https://doc.rust-lang.org/std/keyword.enum.html) in [theme](https://docs.iced.rs/iced/theme/index.html) module support `Custom` variant, e.g., [theme::Radio::Custom(...)](https://docs.iced.rs/iced/theme/enum.Radio.html#variant.Custom).
-This variant takes [radio::StyleSheet](https://docs.iced.rs/iced/widget/radio/trait.StyleSheet.html) trait as its parameter.
+We mentioned in the [previous tutorial](./changing_styles.md) about how to change styles of widgets by the [enums](https://doc.rust-lang.org/std/keyword.enum.html) in [theme](https://docs.rs/iced/0.12.1/iced/theme/index.html) module.
+Most [enums](https://doc.rust-lang.org/std/keyword.enum.html) in [theme](https://docs.rs/iced/0.12.1/iced/theme/index.html) module support `Custom` variant, e.g., [theme::Radio::Custom(...)](https://docs.rs/iced/0.12.1/iced/theme/enum.Radio.html#variant.Custom).
+This variant takes [radio::StyleSheet](https://docs.rs/iced/0.12.1/iced/widget/radio/trait.StyleSheet.html) trait as its parameter.
 To use the variant, we need to implement the trait (such as `RadioStyle` struct in the following code).
-The [associated type](https://doc.rust-lang.org/stable/book/ch19-03-advanced-traits.html#specifying-placeholder-types-in-trait-definitions-with-associated-types) of the trait should be set to [iced::Theme](https://docs.iced.rs/iced/enum.Theme.html).
-The methods in the trait return [radio::Appearance](https://docs.iced.rs/iced/widget/radio/struct.Appearance.html).
-We can use [theme::Radio::Default](https://docs.iced.rs/iced/theme/enum.Radio.html#variant.Default) to obtain the default value of [radio::Appearance](https://docs.iced.rs/iced/widget/radio/struct.Appearance.html), e.g., `style.active(&theme::Radio::Default, is_selected)`.
-After that, we can modify the default [radio::Appearance](https://docs.iced.rs/iced/widget/radio/struct.Appearance.html) based on our needs.
+The [associated type](https://doc.rust-lang.org/stable/book/ch19-03-advanced-traits.html#specifying-placeholder-types-in-trait-definitions-with-associated-types) of the trait should be set to [iced::Theme](https://docs.rs/iced/0.12.1/iced/enum.Theme.html).
+The methods in the trait return [radio::Appearance](https://docs.rs/iced/0.12.1/iced/widget/radio/struct.Appearance.html).
+We can use [theme::Radio::Default](https://docs.rs/iced/0.12.1/iced/theme/enum.Radio.html#variant.Default) to obtain the default value of [radio::Appearance](https://docs.rs/iced/0.12.1/iced/widget/radio/struct.Appearance.html), e.g., `style.active(&theme::Radio::Default, is_selected)`.
+After that, we can modify the default [radio::Appearance](https://docs.rs/iced/0.12.1/iced/widget/radio/struct.Appearance.html) based on our needs.
 
 ```rust
 use iced::{

--- a/tutorial/drawing_shapes.md
+++ b/tutorial/drawing_shapes.md
@@ -1,15 +1,15 @@
 # Drawing Shapes
 
-[Canvas](https://docs.rs/iced/latest/iced/widget/canvas/struct.Canvas.html) is a widget that helps us drawing free-style shapes.
-To use the widget, we need to enable the [canvas](https://docs.rs/crate/iced/latest/features#canvas) feature.
+[Canvas](https://docs.rs/iced/0.12.1/iced/widget/canvas/struct.Canvas.html) is a widget that helps us drawing free-style shapes.
+To use the widget, we need to enable the [canvas](https://docs.rs/crate/iced/0.12.1/features#canvas) feature.
 
 ```toml
 [dependencies]
-iced = { version = "0.10.0", features = ["canvas"] }
+iced = { version = "0.12.1", features = ["canvas"] }
 ```
 
-We use [Canvas::new](https://docs.rs/iced/latest/iced/widget/canvas/struct.Canvas.html#method.new) to obtain the canvas widget.
-This function accepts a [Program](https://docs.rs/iced/latest/iced/widget/canvas/trait.Program.html) trait.
+We use [Canvas::new](https://docs.rs/iced/0.12.1/iced/widget/canvas/struct.Canvas.html#method.new) to obtain the canvas widget.
+This function accepts a [Program](https://docs.rs/iced/0.12.1/iced/widget/canvas/trait.Program.html) trait.
 We can create a struct (say, `MyProgram`) to implement this trait.
 
 ```rust
@@ -29,17 +29,17 @@ impl<Message> Program<Message> for MyProgram {
 }
 ```
 
-There is a generic data type `Message` when we implement the [Program](https://docs.rs/iced/latest/iced/widget/canvas/trait.Program.html) trait.
-This helps us adapting to our [Message](https://docs.rs/iced/latest/iced/trait.Sandbox.html#associatedtype.Message) in [Sandbox](https://docs.rs/iced/latest/iced/trait.Sandbox.html).
+There is a generic data type `Message` when we implement the [Program](https://docs.rs/iced/0.12.1/iced/widget/canvas/trait.Program.html) trait.
+This helps us adapting to our [Message](https://docs.rs/iced/0.12.1/iced/trait.Sandbox.html#associatedtype.Message) in [Sandbox](https://docs.rs/iced/0.12.1/iced/trait.Sandbox.html).
 
-The associated type [State](https://docs.rs/iced/latest/iced/widget/canvas/trait.Program.html#associatedtype.State) is not used in our example, so we set it to `()`.
+The associated type [State](https://docs.rs/iced/0.12.1/iced/widget/canvas/trait.Program.html#associatedtype.State) is not used in our example, so we set it to `()`.
 
-The key of [Program](https://docs.rs/iced/latest/iced/widget/canvas/trait.Program.html) is the [draw](https://docs.rs/iced/latest/iced/widget/canvas/trait.Program.html#tymethod.draw) method.
+The key of [Program](https://docs.rs/iced/0.12.1/iced/widget/canvas/trait.Program.html) is the [draw](https://docs.rs/iced/0.12.1/iced/widget/canvas/trait.Program.html#tymethod.draw) method.
 In the method, we define what shapes we are going to draw.
-We use [Frame](https://docs.rs/iced/latest/iced/widget/canvas/enum.Frame.html) as a *pen* to draw shapes.
-For example, we use the [fill_rectangle](https://docs.rs/iced/latest/iced/widget/canvas/enum.Frame.html#method.fill_rectangle) method of [Frame](https://docs.rs/iced/latest/iced/widget/canvas/enum.Frame.html) to draw a filled rectangle.
-Or we can stroke and fill any [Path](https://docs.rs/iced/latest/iced/widget/canvas/struct.Path.html).
-Finally, we use the [into_geometry](https://docs.rs/iced/latest/iced/widget/canvas/enum.Frame.html#method.into_geometry) method of [Frame](https://docs.rs/iced/latest/iced/widget/canvas/enum.Frame.html) to return the [Geometry](https://docs.rs/iced/latest/iced/widget/canvas/enum.Geometry.html) as required by the [draw](https://docs.rs/iced/latest/iced/widget/canvas/trait.Program.html#tymethod.draw) method.
+We use [Frame](https://docs.rs/iced/0.12.1/iced/widget/canvas/enum.Frame.html) as a *pen* to draw shapes.
+For example, we use the [fill_rectangle](https://docs.rs/iced/0.12.1/iced/widget/canvas/enum.Frame.html#method.fill_rectangle) method of [Frame](https://docs.rs/iced/0.12.1/iced/widget/canvas/enum.Frame.html) to draw a filled rectangle.
+Or we can stroke and fill any [Path](https://docs.rs/iced/0.12.1/iced/widget/canvas/struct.Path.html).
+Finally, we use the [into_geometry](https://docs.rs/iced/0.12.1/iced/widget/canvas/enum.Frame.html#method.into_geometry) method of [Frame](https://docs.rs/iced/0.12.1/iced/widget/canvas/enum.Frame.html) to return the [Geometry](https://docs.rs/iced/0.12.1/iced/widget/canvas/enum.Geometry.html) as required by the [draw](https://docs.rs/iced/0.12.1/iced/widget/canvas/trait.Program.html#tymethod.draw) method.
 
 ```rust
 use iced::{

--- a/tutorial/drawing_widgets.md
+++ b/tutorial/drawing_widgets.md
@@ -1,40 +1,41 @@
 # Drawing Widgets
 
 In addition to the build-in widgets, we can also design our own custom widgets.
-To do so, we need to enable the [advanced](https://docs.rs/crate/iced/latest/features#advanced) feature.
+To do so, we need to enable the [advanced](https://docs.rs/crate/iced/0.12.1/features#advanced) feature.
 The dependencies of the `Cargo.toml` file should look like this:
 
 ```toml
 [dependencies]
-iced = { version = "0.10.0", features = ["advanced"] }
+iced = { version = "0.12.1", features = ["advanced"] }
 ```
 
-Then, we need a struct that implement [Widget](https://docs.rs/iced/latest/iced/advanced/widget/trait.Widget.html) trait.
+Then, we need a struct that implement [Widget](https://docs.rs/iced/0.12.1/iced/advanced/widget/trait.Widget.html) trait.
 
 ```rust
 struct MyWidget;
 
-impl<Message, Renderer> Widget<Message, Renderer> for MyWidget
+impl<Message, Renderer> Widget<Message, Theme, Renderer> for MyWidget
 where
     Renderer: iced::advanced::Renderer,
 {
-    fn width(&self) -> Length {
-        // ...
-    }
-
-    fn height(&self) -> Length {
-        // ...
-    }
-
-    fn layout(&self, _renderer: &Renderer, _limits: &layout::Limits) -> layout::Node {
-        // ...
+	fn size(&self) -> Size<Length> {
+		// ...
+	}
+	
+    fn layout(
+        &self,
+        _tree: &mut Tree,
+        _renderer: &Renderer,
+        _limits: &layout::Limits,
+    ) -> layout::Node {
+		// ...
     }
 
     fn draw(
         &self,
         _state: &Tree,
         _renderer: &mut Renderer,
-        _theme: &Renderer::Theme,
+        _theme: &Theme,
         _style: &renderer::Style,
         _layout: Layout<'_>,
         _cursor: mouse::Cursor,
@@ -45,16 +46,15 @@ where
 }
 ```
 
-We define the size of `MyWidget` by the methods: [width](https://docs.rs/iced/0.10.0/iced/advanced/widget/trait.Widget.html#tymethod.width), [height](https://docs.rs/iced/0.10.0/iced/advanced/widget/trait.Widget.html#tymethod.height) and [layout](https://docs.rs/iced/latest/iced/advanced/widget/trait.Widget.html#tymethod.layout).
-Currently, we set the [width](https://docs.rs/iced/0.10.0/iced/advanced/widget/trait.Widget.html#tymethod.width) and [height](https://docs.rs/iced/0.10.0/iced/advanced/widget/trait.Widget.html#tymethod.height) to [Length::Shrink](https://docs.rs/iced/latest/iced/enum.Length.html#variant.Shrink), to tell the layout system that we use the least space for this widget.
+We define the size of `MyWidget` by the methods: [size](https://docs.rs/iced/0.12.1/iced/advanced/trait.Widget.html#tymethod.size) and [layout](https://docs.rs/iced/0.12.1/iced/advanced/widget/trait.Widget.html#tymethod.layout).
+Currently, we set the width and height to [Length::Shrink](https://docs.rs/iced/0.12.1/iced/enum.Length.html#variant.Shrink), to tell the layout system that we use the least space for this widget.
 
 ```rust
-fn width(&self) -> Length {
-    Length::Shrink
-}
-
-fn height(&self) -> Length {
-    Length::Shrink
+fn size(&self) -> Size<Length> {
+	Size {
+		width: Length::Shrink,
+		height: Length::Shrink,
+	}
 }
 ```
 
@@ -67,42 +67,45 @@ fn layout(&self, _renderer: &Renderer, _limits: &layout::Limits) -> layout::Node
 }
 ```
 
-Usually, the [layout](https://docs.rs/iced/latest/iced/advanced/widget/trait.Widget.html#tymethod.layout) method would consider the [Limits](https://docs.rs/iced/latest/iced/advanced/layout/struct.Limits.html) parameter, which is the constraints from the layout system.
+Usually, the [layout](https://docs.rs/iced/0.12.1/iced/advanced/widget/trait.Widget.html#tymethod.layout) method would consider the [Limits](https://docs.rs/iced/0.12.1/iced/advanced/layout/struct.Limits.html) parameter, which is the constraints from the layout system.
 But now, we ignore it for simplicity.
 
-Next, we draw our widget in the [draw](https://docs.rs/iced/latest/iced/advanced/widget/trait.Widget.html#tymethod.draw) method.
-We use the given [Renderer](https://docs.rs/iced/latest/iced/advanced/trait.Renderer.html) to do so.
-One may refer to the given [Theme](https://docs.rs/iced/0.10.0/iced/advanced/trait.Renderer.html#associatedtype.Theme) and [Style](https://docs.rs/iced/latest/iced/advanced/renderer/struct.Style.html) for the colors of the widget.
+Next, we draw our widget in the [draw](https://docs.rs/iced/0.12.1/iced/advanced/widget/trait.Widget.html#tymethod.draw) method.
+We use the given [Renderer](https://docs.rs/iced/0.12.1/iced/advanced/trait.Renderer.html) to do so.
+One may refer to the given [Theme](https://docs.rs/iced/0.12.1/iced/enum.Theme.html) and [Style](https://docs.rs/iced/0.12.1/iced/advanced/renderer/struct.Style.html) for the colors of the widget.
 
 ```rust
 fn draw(
     &self,
     _state: &Tree,
     renderer: &mut Renderer,
-    _theme: &Renderer::Theme,
+    _theme: &Theme,
     _style: &renderer::Style,
     layout: Layout<'_>,
     _cursor: mouse::Cursor,
     _viewport: &Rectangle,
 ) {
     renderer.fill_quad(
-        Quad {
-            bounds: layout.bounds(),
-            border_radius: 10.0.into(),
-            border_width: 1.0,
-            border_color: Color::from_rgb(0.6, 0.8, 1.0),
-        },
+		Quad {
+			bounds: layout.bounds(),
+			border: Border {
+				color: Color::from_rgb(0.6, 0.8, 1.0),
+				width: 1.0,
+				radius: 10.0.into(),
+			},
+			shadow: Shadow::default(),
+		},
         Color::from_rgb(0.0, 0.2, 0.4),
     );
 }
 ```
 
-The given [Layout](https://docs.rs/iced/latest/iced/advanced/struct.Layout.html) parameter would be calculated automatically by the layout system according to the [width](https://docs.rs/iced/0.10.0/iced/advanced/widget/trait.Widget.html#tymethod.width), [height](https://docs.rs/iced/0.10.0/iced/advanced/widget/trait.Widget.html#tymethod.height) and [layout](https://docs.rs/iced/latest/iced/advanced/widget/trait.Widget.html#tymethod.layout) methods we defined before.
+The given [Layout](https://docs.rs/iced/0.12.1/iced/advanced/struct.Layout.html) parameter would be calculated automatically by the layout system according to the [size](https://docs.rs/iced/0.12.1/iced/advanced/trait.Widget.html#tymethod.size) and [layout](https://docs.rs/iced/0.12.1/iced/advanced/widget/trait.Widget.html#tymethod.layout) methods we defined before.
 
-For convenience, we can implement `From<MyWidget>` for [Element](https://docs.rs/iced/latest/iced/type.Element.html).
+For convenience, we can implement `From<MyWidget>` for [Element](https://docs.rs/iced/0.12.1/iced/type.Element.html).
 
 ```rust
-impl<'a, Message, Renderer> From<MyWidget> for Element<'a, Message, Renderer>
+impl<'a, Message, Renderer> From<MyWidget> for Element<'a, Message, Theme, Renderer>
 where
     Renderer: iced::advanced::Renderer,
 {
@@ -125,7 +128,7 @@ fn view(&self) -> iced::Element<'_, Self::Message> {
 }
 ```
 
-Note that it is not necessary to put `MyWidget` in a [Container](https://docs.rs/iced/latest/iced/widget/container/struct.Container.html).
+Note that it is not necessary to put `MyWidget` in a [Container](https://docs.rs/iced/0.12.1/iced/widget/container/struct.Container.html).
 We can add the widget directly into our app.
 
 ```rust
@@ -145,7 +148,7 @@ use iced::{
         Layout, Widget,
     },
     widget::container,
-    Color, Element, Length, Rectangle, Sandbox, Settings,
+    Border, Color, Element, Length, Rectangle, Sandbox, Settings, Shadow, Size, Theme,
 };
 
 fn main() -> iced::Result {
@@ -179,19 +182,23 @@ impl Sandbox for MyApp {
 
 struct MyWidget;
 
-impl<Message, Renderer> Widget<Message, Renderer> for MyWidget
+impl<Message, Renderer> Widget<Message, Theme, Renderer> for MyWidget
 where
     Renderer: iced::advanced::Renderer,
 {
-    fn width(&self) -> Length {
-        Length::Shrink
+    fn size(&self) -> Size<Length> {
+        Size {
+            width: Length::Shrink,
+            height: Length::Shrink,
+        }
     }
 
-    fn height(&self) -> Length {
-        Length::Shrink
-    }
-
-    fn layout(&self, _renderer: &Renderer, _limits: &layout::Limits) -> layout::Node {
+    fn layout(
+        &self,
+        _tree: &mut Tree,
+        _renderer: &Renderer,
+        _limits: &layout::Limits,
+    ) -> layout::Node {
         layout::Node::new([100, 100].into())
     }
 
@@ -199,7 +206,7 @@ where
         &self,
         _state: &Tree,
         renderer: &mut Renderer,
-        _theme: &Renderer::Theme,
+        _theme: &Theme,
         _style: &renderer::Style,
         layout: Layout<'_>,
         _cursor: mouse::Cursor,
@@ -208,16 +215,19 @@ where
         renderer.fill_quad(
             Quad {
                 bounds: layout.bounds(),
-                border_radius: 10.0.into(),
-                border_width: 1.0,
-                border_color: Color::from_rgb(0.6, 0.8, 1.0),
+                border: Border {
+                    color: Color::from_rgb(0.6, 0.8, 1.0),
+                    width: 1.0,
+                    radius: 10.0.into(),
+                },
+                shadow: Shadow::default(),
             },
             Color::from_rgb(0.0, 0.2, 0.4),
         );
     }
 }
 
-impl<'a, Message, Renderer> From<MyWidget> for Element<'a, Message, Renderer>
+impl<'a, Message, Renderer> From<MyWidget> for Element<'a, Message, Theme, Renderer>
 where
     Renderer: iced::advanced::Renderer,
 {

--- a/tutorial/drawing_with_caches.md
+++ b/tutorial/drawing_with_caches.md
@@ -1,10 +1,10 @@
 # Drawing With Caches
 
-Previously, we mentioned that [Program](https://docs.rs/iced/latest/iced/widget/canvas/trait.Program.html) has the method [draw](https://docs.rs/iced/latest/iced/widget/canvas/trait.Program.html#tymethod.draw) that every time the corresponding [Canvas](https://docs.rs/iced/latest/iced/widget/canvas/struct.Canvas.html) needed to be re-drawn, the method is called.
-However, if the shapes of the [Canvas](https://docs.rs/iced/latest/iced/widget/canvas/struct.Canvas.html) remain unchanged, it is not performant to re-draw all these shapes.
-Instead, we store an image of these shapes in a [Cache](https://docs.rs/iced/latest/iced/widget/canvas/struct.Cache.html), and we draw this cache when the [draw](https://docs.rs/iced/latest/iced/widget/canvas/trait.Program.html#tymethod.draw) method of [Program](https://docs.rs/iced/latest/iced/widget/canvas/trait.Program.html) is called.
+Previously, we mentioned that [Program](https://docs.rs/iced/0.12.1/iced/widget/canvas/trait.Program.html) has the method [draw](https://docs.rs/iced/0.12.1/iced/widget/canvas/trait.Program.html#tymethod.draw) that every time the corresponding [Canvas](https://docs.rs/iced/0.12.1/iced/widget/canvas/struct.Canvas.html) needed to be re-drawn, the method is called.
+However, if the shapes of the [Canvas](https://docs.rs/iced/0.12.1/iced/widget/canvas/struct.Canvas.html) remain unchanged, it is not performant to re-draw all these shapes.
+Instead, we store an image of these shapes in a [Cache](https://docs.rs/iced/0.12.1/iced/widget/canvas/struct.Cache.html), and we draw this cache when the [draw](https://docs.rs/iced/0.12.1/iced/widget/canvas/trait.Program.html#tymethod.draw) method of [Program](https://docs.rs/iced/0.12.1/iced/widget/canvas/trait.Program.html) is called.
 
-To do so, we declare a field of type [Cache](https://docs.rs/iced/latest/iced/widget/canvas/struct.Cache.html) in our app
+To do so, we declare a field of type [Cache](https://docs.rs/iced/0.12.1/iced/widget/canvas/struct.Cache.html) in our app
 
 ```rust
 struct MyApp {
@@ -22,7 +22,7 @@ fn new() -> Self {
 }
 ```
 
-In the [draw](https://docs.rs/iced/latest/iced/widget/canvas/trait.Program.html#tymethod.draw) method, instead of creating a new [Frame](https://docs.rs/iced/latest/iced/widget/canvas/enum.Frame.html)
+In the [draw](https://docs.rs/iced/0.12.1/iced/widget/canvas/trait.Program.html#tymethod.draw) method, instead of creating a new [Frame](https://docs.rs/iced/0.12.1/iced/widget/canvas/enum.Frame.html)
 
 ```rust
 let mut frame = Frame::new(renderer, bounds.size());
@@ -30,7 +30,7 @@ let mut frame = Frame::new(renderer, bounds.size());
 vec![frame.into_geometry()]
 ```
 
-we use [cache.draw](https://docs.rs/iced/latest/iced/widget/canvas/struct.Cache.html#method.draw) to construct the [Geometry](https://docs.rs/iced/latest/iced/widget/canvas/enum.Geometry.html).
+we use [cache.draw](https://docs.rs/iced/0.12.1/iced/widget/canvas/struct.Cache.html#method.draw) to construct the [Geometry](https://docs.rs/iced/0.12.1/iced/widget/canvas/enum.Geometry.html).
 
 ```rust
 let geometry = self.cache.draw(renderer, bounds.size(), |frame| {
@@ -42,8 +42,8 @@ vec![geometry]
 
 The closure `|frame| { /* ... */ }` is only called when the dimensions of the `frame` change or the cache is explicitly cleared.
 
-In addition, previously, we implement [Program](https://docs.rs/iced/latest/iced/widget/canvas/trait.Program.html) for the struct `MyProgram`.
-But because we need to access the `cache` field of `MyApp`, we have to implement [Program](https://docs.rs/iced/latest/iced/widget/canvas/trait.Program.html) for `MyApp`.
+In addition, previously, we implement [Program](https://docs.rs/iced/0.12.1/iced/widget/canvas/trait.Program.html) for the struct `MyProgram`.
+But because we need to access the `cache` field of `MyApp`, we have to implement [Program](https://docs.rs/iced/0.12.1/iced/widget/canvas/trait.Program.html) for `MyApp`.
 
 The full code is as follows:
 

--- a/tutorial/executing_custom_commands.md
+++ b/tutorial/executing_custom_commands.md
@@ -1,7 +1,7 @@
 # Executing Custom Commands
 
-[Commands](https://docs.iced.rs/iced/struct.Command.html) can help us executing asynchronous functions.
-To do this, we need to enable one of the following features: [tokio](https://docs.rs/crate/iced/latest/features#tokio), [async-std](https://docs.rs/crate/iced/latest/features#async-std), or [smol](https://docs.rs/crate/iced/latest/features#smol).
+[Commands](https://docs.rs/iced/0.12.1/iced/struct.Command.html) can help us executing asynchronous functions.
+To do this, we need to enable one of the following features: [tokio](https://docs.rs/crate/iced/0.12.1/features#tokio), [async-std](https://docs.rs/crate/iced/0.12.1/features#async-std), or [smol](https://docs.rs/crate/iced/0.12.1/features#smol).
 The corresponding asynchronous runtime ([tokio](https://crates.io/crates/tokio), [async-std](https://crates.io/crates/async-std), or [smol](https://crates.io/crates/smol)) must also be added.
 
 Here, we use [async-std](https://crates.io/crates/async-std) as an example.
@@ -11,11 +11,11 @@ The `Cargo.toml` should look like this:
 ```toml
 [dependencies]
 async-std = "1.12.0"
-iced = { version = "0.10.0", features = ["async-std"] }
+iced = { version = "0.12.1", features = ["async-std"] }
 ```
 
-We use [Command::perform](https://docs.iced.rs/iced/struct.Command.html#method.perform) to execute an asynchronous function.
-The first parameter of [Command::perform](https://docs.iced.rs/iced/struct.Command.html#method.perform) is an asynchronous function, and the second parameter is a function that returns `MyAppMessage`.
+We use [Command::perform](https://docs.rs/iced/0.12.1/iced/struct.Command.html#method.perform) to execute an asynchronous function.
+The first parameter of [Command::perform](https://docs.rs/iced/0.12.1/iced/struct.Command.html#method.perform) is an asynchronous function, and the second parameter is a function that returns `MyAppMessage`.
 The `MyAppMessage` will be produced once the asynchronous function is done.
 
 In the following code, we use a simple asynchronous function [async_std::task::sleep](https://docs.rs/async-std/1.12.0/async_std/task/fn.sleep.html).

--- a/tutorial/explanation_of_sandbox_trait.md
+++ b/tutorial/explanation_of_sandbox_trait.md
@@ -1,6 +1,6 @@
 # Explanation of Sandbox Trait
 
-[Sandbox](https://docs.iced.rs/iced/trait.Sandbox.html) works as follows.
+[Sandbox](https://docs.rs/iced/0.12.1/iced/trait.Sandbox.html) works as follows.
 
 ![Sandbox trait](./pic/explanation_of_sandbox_trait.png)
 

--- a/tutorial/first_app.md
+++ b/tutorial/first_app.md
@@ -1,7 +1,7 @@
 # First App - Hello World!
 
-We need a struct to implement [Sandbox](https://docs.iced.rs/iced/trait.Sandbox.html), and call its [run](https://docs.iced.rs/iced/trait.Sandbox.html#method.run) method from `main`.
-All widgets should be placed inside the [view](https://docs.iced.rs/iced/trait.Sandbox.html#tymethod.view) method.
+We need a struct to implement [Sandbox](https://docs.rs/iced/0.12.1/iced/trait.Sandbox.html), and call its [run](https://docs.rs/iced/0.12.1/iced/trait.Sandbox.html#method.run) method from `main`.
+All widgets should be placed inside the [view](https://docs.rs/iced/0.12.1/iced/trait.Sandbox.html#tymethod.view) method.
 
 ```rust
 use iced::{Sandbox, Settings};

--- a/tutorial/from_sandbox_to_application.md
+++ b/tutorial/from_sandbox_to_application.md
@@ -1,12 +1,12 @@
 # From Sandbox To Application
 
-To have more control over our app, we can use [Application](https://docs.iced.rs/iced/application/trait.Application.html) trait, which is a generalization of [Sandbox](https://docs.iced.rs/iced/trait.Sandbox.html) trait.
-There are two main differences between [Application](https://docs.iced.rs/iced/application/trait.Application.html) and [Sandbox](https://docs.iced.rs/iced/trait.Sandbox.html).
+To have more control over our app, we can use [Application](https://docs.rs/iced/0.12.1/iced/application/trait.Application.html) trait, which is a generalization of [Sandbox](https://docs.rs/iced/0.12.1/iced/trait.Sandbox.html) trait.
+There are two main differences between [Application](https://docs.rs/iced/0.12.1/iced/application/trait.Application.html) and [Sandbox](https://docs.rs/iced/0.12.1/iced/trait.Sandbox.html).
 One thing is the [associated types](https://doc.rust-lang.org/stable/book/ch19-03-advanced-traits.html#specifying-placeholder-types-in-trait-definitions-with-associated-types).
-We have to specify [Executor](https://docs.iced.rs/iced/application/trait.Application.html#associatedtype.Executor), [Theme](https://docs.iced.rs/iced/application/trait.Application.html#associatedtype.Theme) and [Flags](https://docs.iced.rs/iced/application/trait.Application.html#associatedtype.Flags) in addition to [Message](https://docs.iced.rs/iced/trait.Sandbox.html#associatedtype.Message) in [Sandbox](https://docs.iced.rs/iced/trait.Sandbox.html).
+We have to specify [Executor](https://docs.rs/iced/0.12.1/iced/application/trait.Application.html#associatedtype.Executor), [Theme](https://docs.rs/iced/0.12.1/iced/application/trait.Application.html#associatedtype.Theme) and [Flags](https://docs.rs/iced/0.12.1/iced/application/trait.Application.html#associatedtype.Flags) in addition to [Message](https://docs.rs/iced/0.12.1/iced/trait.Sandbox.html#associatedtype.Message) in [Sandbox](https://docs.rs/iced/0.12.1/iced/trait.Sandbox.html).
 Basically, we use the suggested defaults for these associated types.
-The other is that we have to return [Command](https://docs.iced.rs/iced/struct.Command.html) in [new](https://docs.iced.rs/iced/application/trait.Application.html#tymethod.new) method and [update](https://docs.iced.rs/iced/application/trait.Application.html#tymethod.update) method.
-We just return [Command::none()](https://docs.iced.rs/iced/struct.Command.html#method.none) for both methods.
+The other is that we have to return [Command](https://docs.rs/iced/0.12.1/iced/struct.Command.html) in [new](https://docs.rs/iced/0.12.1/iced/application/trait.Application.html#tymethod.new) method and [update](https://docs.rs/iced/0.12.1/iced/application/trait.Application.html#tymethod.update) method.
+We just return [Command::none()](https://docs.rs/iced/0.12.1/iced/struct.Command.html#method.none) for both methods.
 
 ```rust
 use iced::{executor, Application, Command, Settings};
@@ -35,7 +35,7 @@ impl Application for MyApp {
         Command::none()
     }
 
-    fn view(&self) -> iced::Element<'_, Self::Message, iced::Renderer<Self::Theme>> {
+    fn view(&self) -> iced::Element<'_, Self::Message> {
         "Hello World!".into()
     }
 }

--- a/tutorial/image.md
+++ b/tutorial/image.md
@@ -1,15 +1,15 @@
 # Image
 
-The [Image](https://docs.iced.rs/iced/widget/image/struct.Image.html) widget is able to display an image.
+The [Image](https://docs.rs/iced/0.12.1/iced/widget/image/struct.Image.html) widget is able to display an image.
 It has two methods of constructions.
 We can set how to fit the image content into the widget bounds.
 
-To use the widget, we have to enable the [image](https://docs.rs/crate/iced/latest/features#image) feature.
+To use the widget, we have to enable the [image](https://docs.rs/iced/0.12.1/iced/latest/features#image) feature.
 The `Cargo.toml` dependencies should look like this:
 
 ```toml
 [dependencies]
-iced = { version = "0.10.0", features = ["image"] }
+iced = { version = "0.12.1", features = ["image"] }
 ```
 
 Assume we have an image named `ferris.png` in the project root directory, i.e., the image has the path `my_project/ferris.png` where `my_project` is the name of our project.

--- a/tutorial/initializing_a_different_window.md
+++ b/tutorial/initializing_a_different_window.md
@@ -1,16 +1,19 @@
 # Initializing A Different Window
 
-We can use [window::Settings](https://docs.iced.rs/iced/window/settings/struct.Settings.html) to change the properties of the window (such as [position](https://docs.iced.rs/iced/window/settings/struct.Settings.html#structfield.position) and [size](https://docs.iced.rs/iced/window/settings/struct.Settings.html#structfield.size)) when we call [run](https://docs.iced.rs/iced/trait.Sandbox.html#method.run) of a [Sandbox](https://docs.iced.rs/iced/trait.Sandbox.html) or [Application](https://docs.iced.rs/iced/application/trait.Application.html).
-Developers might be interested in reading the document of [window::Settings](https://docs.iced.rs/iced/window/settings/struct.Settings.html) for other properties.
+We can use [window::Settings](https://docs.rs/iced/0.12.1/iced/window/settings/struct.Settings.html) to change the properties of the window (such as [position](https://docs.rs/iced/0.12.1/iced/window/settings/struct.Settings.html#structfield.position) and [size](https://docs.rs/iced/0.12.1/iced/window/settings/struct.Settings.html#structfield.size)) when we call [run](https://docs.rs/iced/0.12.1/iced/trait.Sandbox.html#method.run) of a [Sandbox](https://docs.rs/iced/0.12.1/iced/trait.Sandbox.html) or [Application](https://docs.rs/iced/0.12.1/iced/application/trait.Application.html).
+Developers might be interested in reading the document of [window::Settings](https://docs.rs/iced/0.12.1/iced/window/settings/struct.Settings.html) for other properties.
 
 ```rust
-use iced::{window, Sandbox, Settings};
+use iced::{window, Point, Sandbox, Settings, Size};
 
 fn main() -> iced::Result {
     MyApp::run(Settings {
         window: window::Settings {
-            size: (70, 20),
-            position: window::Position::Specific(50, 60),
+            size: Size {
+                width: 70.,
+                height: 20.,
+            },
+            position: window::Position::Specific(Point { x: 50., y: 60. }),
             ..window::Settings::default()
         },
         ..Settings::default()

--- a/tutorial/loading_images_asynchronously.md
+++ b/tutorial/loading_images_asynchronously.md
@@ -1,6 +1,6 @@
 # Loading Images Asynchronously
 
-In the previous tutorials, we introduced how to use [Application](https://docs.rs/iced/latest/iced/application/trait.Application.html) to execute an asynchronous operation and how to display an image.
+In the previous tutorials, we introduced how to use [Application](https://docs.rs/iced/0.12.1/iced/application/trait.Application.html) to execute an asynchronous operation and how to display an image.
 This tutorial combines both and demonstrates how to load an image asynchronously.
 
 It is assumed that there is an image named `ferris.png` in the Cargo project root directory.
@@ -10,7 +10,7 @@ The dependencies of the `Cargo.toml` file should look like this:
 
 ```toml
 [dependencies]
-iced = { version = "0.10.0", features = ["image", "tokio"] }
+iced = { version = "0.12.1", features = ["image", "tokio"] }
 tokio = { version = "1.36.0", features = ["full"] }
 ```
 
@@ -155,7 +155,7 @@ impl Application for MyApp {
         Command::none()
     }
 
-    fn view(&self) -> iced::Element<'_, Self::Message, iced::Renderer<Self::Theme>> {
+    fn view(&self) -> iced::Element<'_, Self::Message> {
         column![
             button("Load").on_press(MyMessage::Load),
             if self.show_container {

--- a/tutorial/memoryless_pages.md
+++ b/tutorial/memoryless_pages.md
@@ -4,9 +4,9 @@ The [previous tutorial](./more_than_one_page.md) has a problem that the fields c
 This brings potential security problems, e.g., the input password could be accessed in other pages.
 
 To fix this problem, we can use [trait objects](https://doc.rust-lang.org/stable/book/ch17-02-trait-objects.html).
-The `Page` trait below is responsible for [update](https://docs.iced.rs/iced/trait.Sandbox.html#tymethod.update) and [view](https://docs.iced.rs/iced/trait.Sandbox.html#tymethod.view) for a single page.
-In the main struct `MyApp`, we dispatch [update](https://docs.iced.rs/iced/trait.Sandbox.html#tymethod.update) and [view](https://docs.iced.rs/iced/trait.Sandbox.html#tymethod.view) to the corresponding page that is indicated by `page` field in `MyApp`.
-The [update](https://docs.iced.rs/iced/trait.Sandbox.html#tymethod.update) method in `MyApp` is also responsible for switching pages.
+The `Page` trait below is responsible for [update](https://docs.rs/iced/0.12.1/iced/trait.Sandbox.html#tymethod.update) and [view](https://docs.rs/iced/0.12.1/iced/trait.Sandbox.html#tymethod.view) for a single page.
+In the main struct `MyApp`, we dispatch [update](https://docs.rs/iced/0.12.1/iced/trait.Sandbox.html#tymethod.update) and [view](https://docs.rs/iced/0.12.1/iced/trait.Sandbox.html#tymethod.view) to the corresponding page that is indicated by `page` field in `MyApp`.
+The [update](https://docs.rs/iced/0.12.1/iced/trait.Sandbox.html#tymethod.update) method in `MyApp` is also responsible for switching pages.
 
 In addition, we explicitly distinguish messages from different pages in `MyAppMessage`.
 
@@ -146,7 +146,7 @@ impl Page for PageA {
     fn view(&self) -> iced::Element<'_, MyAppMessage> {
         column![
             text_input("Password", &self.password)
-                .password()
+                .secure(true)
                 .on_input(|s| MyAppMessage::PageA(Ma::TextChanged(s))),
             button("Log in").on_press(MyAppMessage::PageA(Ma::ButtonPressed)),
         ]

--- a/tutorial/more_than_one_page.md
+++ b/tutorial/more_than_one_page.md
@@ -1,7 +1,7 @@
 # More Than One Page
 
 To have multiple pages, we can add a field `page` to the main struct `MyApp`.
-The field `page` is an [enum](https://doc.rust-lang.org/std/keyword.enum.html) defined by us that decides what to display in [view](https://docs.rs/iced/latest/iced/trait.Sandbox.html#tymethod.view) method of the [Sandbox](https://docs.iced.rs/iced/trait.Sandbox.html).
+The field `page` is an [enum](https://doc.rust-lang.org/std/keyword.enum.html) defined by us that decides what to display in [view](https://docs.rs/iced/0.12.1/iced/trait.Sandbox.html#tymethod.view) method of the [Sandbox](https://docs.rs/iced/0.12.1/iced/trait.Sandbox.html).
 
 ```rust
 use iced::{

--- a/tutorial/mouse_pointer_over_widgets.md
+++ b/tutorial/mouse_pointer_over_widgets.md
@@ -1,6 +1,6 @@
 # Mouse Pointer Over Widgets
 
-To change the mouse pointer based on the requirement of our widgets, we can use the [mouse_interaction](https://docs.rs/iced/latest/iced/advanced/widget/trait.Widget.html#method.mouse_interaction) method of [Widget](https://docs.rs/iced/latest/iced/advanced/widget/trait.Widget.html).
+To change the mouse pointer based on the requirement of our widgets, we can use the [mouse_interaction](https://docs.rs/iced/0.12.1/iced/advanced/widget/trait.Widget.html#method.mouse_interaction) method of [Widget](https://docs.rs/iced/0.12.1/iced/advanced/widget/trait.Widget.html).
 
 ```rust
 fn mouse_interaction(
@@ -19,8 +19,8 @@ fn mouse_interaction(
 }
 ```
 
-The method returns [Interaction](https://docs.rs/iced/latest/iced/mouse/enum.Interaction.html), which specifies the type of the mouse pointer.
-In our example, we specify [Interaction::Pointer](https://docs.rs/iced/latest/iced/mouse/enum.Interaction.html#variant.Pointer) when the mouse is over the widget.
+The method returns [Interaction](https://docs.rs/iced/0.12.1/iced/mouse/enum.Interaction.html), which specifies the type of the mouse pointer.
+In our example, we specify [Interaction::Pointer](https://docs.rs/iced/0.12.1/iced/mouse/enum.Interaction.html#variant.Pointer) when the mouse is over the widget.
 
 The full code is as follows:
 
@@ -33,7 +33,7 @@ use iced::{
         Layout, Widget,
     },
     widget::container,
-    Color, Element, Length, Rectangle, Sandbox, Settings,
+    Border, Color, Element, Length, Rectangle, Sandbox, Settings, Shadow, Size, Theme,
 };
 
 fn main() -> iced::Result {
@@ -67,19 +67,23 @@ impl Sandbox for MyApp {
 
 struct MyWidget;
 
-impl<Message, Renderer> Widget<Message, Renderer> for MyWidget
+impl<Message, Renderer> Widget<Message, Theme, Renderer> for MyWidget
 where
     Renderer: iced::advanced::Renderer,
 {
-    fn width(&self) -> Length {
-        Length::Shrink
+    fn size(&self) -> Size<Length> {
+        Size {
+            width: Length::Shrink,
+            height: Length::Shrink,
+        }
     }
 
-    fn height(&self) -> Length {
-        Length::Shrink
-    }
-
-    fn layout(&self, _renderer: &Renderer, _limits: &layout::Limits) -> layout::Node {
+    fn layout(
+        &self,
+        _tree: &mut Tree,
+        _renderer: &Renderer,
+        _limits: &layout::Limits,
+    ) -> layout::Node {
         layout::Node::new([100, 100].into())
     }
 
@@ -87,7 +91,7 @@ where
         &self,
         _state: &Tree,
         renderer: &mut Renderer,
-        _theme: &Renderer::Theme,
+        _theme: &Theme,
         _style: &renderer::Style,
         layout: Layout<'_>,
         _cursor: mouse::Cursor,
@@ -96,9 +100,12 @@ where
         renderer.fill_quad(
             Quad {
                 bounds: layout.bounds(),
-                border_radius: 10.0.into(),
-                border_width: 1.0,
-                border_color: Color::from_rgb(0.6, 0.8, 1.0),
+                border: Border {
+                    color: Color::from_rgb(0.6, 0.8, 1.0),
+                    width: 1.0,
+                    radius: 10.0.into(),
+                },
+                shadow: Shadow::default(),
             },
             Color::from_rgb(0.0, 0.2, 0.4),
         );
@@ -120,9 +127,10 @@ where
     }
 }
 
-impl<'a, Message, Renderer> From<MyWidget> for Element<'a, Message, Renderer>
+impl<'a, Message, Renderer> From<MyWidget> for Element<'a, Message, Theme, Renderer>
 where
     Renderer: iced::advanced::Renderer,
+    Message: Clone + 'a,
 {
     fn from(widget: MyWidget) -> Self {
         Self::new(widget)

--- a/tutorial/navigation_history.md
+++ b/tutorial/navigation_history.md
@@ -4,8 +4,8 @@ This tutorial follows the [previous tutorial](./passing_parameters_across_pages.
 The framework introduced in the [previous tutorial](./passing_parameters_across_pages.md) can be extended to handle page navigation history, which is capable of restoring past pages.
 
 Instead of keeping a single page in the main struct `MyApp`, we can keep a [Vec](https://doc.rust-lang.org/std/vec/struct.Vec.html) of pages.
-We control how the [Vec](https://doc.rust-lang.org/std/vec/struct.Vec.html) would change in [update](https://docs.iced.rs/iced/trait.Sandbox.html#tymethod.update) method of [SandBox](https://docs.iced.rs/iced/trait.Sandbox.html).
-The communication between [update](https://docs.iced.rs/iced/trait.Sandbox.html#tymethod.update) of [Sandbox](https://docs.iced.rs/iced/trait.Sandbox.html) and `update` of `Page` trait is through a custom [enum](https://doc.rust-lang.org/std/keyword.enum.html) `Navigation`.
+We control how the [Vec](https://doc.rust-lang.org/std/vec/struct.Vec.html) would change in [update](https://docs.rs/iced/0.12.1/iced/trait.Sandbox.html#tymethod.update) method of [SandBox](https://docs.rs/iced/0.12.1/iced/trait.Sandbox.html).
+The communication between [update](https://docs.rs/iced/0.12.1/iced/trait.Sandbox.html#tymethod.update) of [Sandbox](https://docs.rs/iced/0.12.1/iced/trait.Sandbox.html) and `update` of `Page` trait is through a custom [enum](https://doc.rust-lang.org/std/keyword.enum.html) `Navigation`.
 
 ```rust
 use iced::{

--- a/tutorial/on_pressed_released_of_some_widgets.md
+++ b/tutorial/on_pressed_released_of_some_widgets.md
@@ -1,8 +1,8 @@
 # On Pressed/Released Of Some Widgets
 
-If we only consider mouse pressed or released events, we can use [MouseArea](https://docs.iced.rs/iced/widget/struct.MouseArea.html).
-The [MouseArea](https://docs.iced.rs/iced/widget/struct.MouseArea.html) gives the widget being put in it the sense of mouse pressed/released events, even if the widget has no build-in support of the events.
-For example, we can make a [Text](https://docs.iced.rs/iced/widget/type.Text.html) to respond to mouse pressed/released events.
+If we only consider mouse pressed or released events, we can use [MouseArea](https://docs.rs/iced/0.12.1/iced/widget/struct.MouseArea.html).
+The [MouseArea](https://docs.rs/iced/0.12.1/iced/widget/struct.MouseArea.html) gives the widget being put in it the sense of mouse pressed/released events, even if the widget has no build-in support of the events.
+For example, we can make a [Text](https://docs.rs/iced/0.12.1/iced/widget/type.Text.html) to respond to mouse pressed/released events.
 
 ```rust
 use iced::{widget::mouse_area, Sandbox, Settings};
@@ -50,7 +50,7 @@ impl Sandbox for MyApp {
 }
 ```
 
-In addition to [on_press](https://docs.iced.rs/iced/widget/struct.MouseArea.html#method.on_press) and [on_release](https://docs.iced.rs/iced/widget/struct.MouseArea.html#method.on_release) methods, [MouseArea](https://docs.iced.rs/iced/widget/struct.MouseArea.html) also supports [on_middle_press](https://docs.iced.rs/iced/widget/struct.MouseArea.html#method.on_middle_press), [on_right_press](https://docs.iced.rs/iced/widget/struct.MouseArea.html#method.on_right_press), etc.
+In addition to [on_press](https://docs.rs/iced/0.12.1/iced/widget/struct.MouseArea.html#method.on_press) and [on_release](https://docs.rs/iced/0.12.1/iced/widget/struct.MouseArea.html#method.on_release) methods, [MouseArea](https://docs.rs/iced/0.12.1/iced/widget/struct.MouseArea.html) also supports [on_middle_press](https://docs.rs/iced/0.12.1/iced/widget/struct.MouseArea.html#method.on_middle_press), [on_right_press](https://docs.rs/iced/0.12.1/iced/widget/struct.MouseArea.html#method.on_right_press), etc.
 
 When the mouse is pressed:
 

--- a/tutorial/passing_parameters_across_pages.md
+++ b/tutorial/passing_parameters_across_pages.md
@@ -54,7 +54,7 @@ impl Sandbox for MyApp {
 }
 ```
 
-For `PageA` (the login form), we have a [TextInput](https://docs.iced.rs/iced/widget/struct.TextInput.html) for names and a submit [Button](https://docs.iced.rs/iced/widget/struct.Button.html).
+For `PageA` (the login form), we have a [TextInput](https://docs.rs/iced/0.12.1/iced/widget/struct.TextInput.html) for names and a submit [Button](https://docs.rs/iced/0.12.1/iced/widget/struct.Button.html).
 We pass `name` field of `PageA` to `new` function of `PageB` when we press the submit button.
 
 ```rust

--- a/tutorial/pickList.md
+++ b/tutorial/pickList.md
@@ -1,6 +1,6 @@
 # PickList
 
-The [PickList](https://docs.iced.rs/iced/widget/pick_list/struct.PickList.html) widget represents a choice among multiple values.
+The [PickList](https://docs.rs/iced/0.12.1/iced/widget/pick_list/struct.PickList.html) widget represents a choice among multiple values.
 It has two methods of constructions.
 It supports reactions to option selections.
 A placeholder can be set when options are not selected yet.
@@ -12,7 +12,7 @@ We can also change the icon of the handle.
 use iced::{
     font::Family,
     widget::{column, pick_list, pick_list::Handle, text::Shaping, PickList},
-    Font, Sandbox, Settings,
+    Font, Pixels, Sandbox, Settings,
 };
 
 fn main() -> iced::Result {
@@ -68,7 +68,7 @@ impl Sandbox for MyApp {
                 self.pick_list_3.clone(),
                 |s| MyAppMessage::Update3(s)
             ),
-            pick_list(vec!["A", "B", "C"], None, |_| MyAppMessage::DoNothing)
+            pick_list(vec!["A", "B", "C"], None::<&str>, |_| MyAppMessage::DoNothing)
                 .placeholder("Placeholder"),
             pick_list(vec!["Different font"], Some("Different font"), |_| {
                 MyAppMessage::DoNothing
@@ -94,7 +94,7 @@ impl Sandbox for MyApp {
             pick_list(vec!["Different handle"], Some("Different handle"), |_| {
                 MyAppMessage::DoNothing
             })
-            .handle(Handle::Arrow { size: Some(24.) }),
+            .handle(Handle::Arrow { size: Some(Pixels(24.)) }),
         ]
         .into()
     }

--- a/tutorial/producing_messages_by_keyboard_events.md
+++ b/tutorial/producing_messages_by_keyboard_events.md
@@ -1,16 +1,13 @@
 # Producing Messages By Keyboard Events
 
 This tutorial follows from the [previous tutorial](./producing_messages_by_mouse_events.md).
-Instead of capturing [Event::Mouse](https://docs.iced.rs/iced/event/enum.Event.html#variant.Mouse) and [Event::Touch](https://docs.iced.rs/iced/event/enum.Event.html#variant.Touch), we capture [Event::Keyboard](https://docs.iced.rs/iced/event/enum.Event.html#variant.Keyboard) in the [events_with](https://docs.rs/iced/latest/iced/subscription/fn.events_with.html) function.
-
-Note: [events_with](https://docs.rs/iced/latest/iced/subscription/fn.events_with.html) will be deprecated.
-If you cannot find this function, try using [listen_with](https://docs.iced.rs/iced/event/fn.listen_with.html).
+Instead of capturing [Event::Mouse](https://docs.rs/iced/0.12.1/iced/event/enum.Event.html#variant.Mouse) and [Event::Touch](https://docs.rs/iced/0.12.1/iced/event/enum.Event.html#variant.Touch), we capture [Event::Keyboard](https://docs.rs/iced/0.12.1/iced/event/enum.Event.html#variant.Keyboard) in the [listen_with](https://docs.rs/iced/0.12.1/iced/event/fn.listen_with.html) function.
 
 ```rust
 use iced::{
-    event::Status,
+    event::{self, Status},
     executor,
-    keyboard::{Event::KeyPressed, KeyCode},
+    keyboard::{Event::KeyPressed, Key},
     subscription,
     widget::text,
     Application, Event, Settings,
@@ -55,7 +52,7 @@ impl Application for MyApp {
         iced::Command::none()
     }
 
-    fn view(&self) -> iced::Element<'_, Self::Message, iced::Renderer<Self::Theme>> {
+    fn view(&self) -> iced::Element<'_, Self::Message> {
         text(self.pressed_key.as_str()).into()
     }
 
@@ -63,14 +60,14 @@ impl Application for MyApp {
         subscription::events_with(|event, status| match (event, status) {
             (
                 Event::Keyboard(KeyPressed {
-                    key_code: KeyCode::Enter,
+                    key: Key::Named(Named::Enter),
                     ..
                 }),
                 Status::Ignored,
             ) => Some(MyAppMessage::KeyPressed("Enter".into())),
             (
                 Event::Keyboard(KeyPressed {
-                    key_code: KeyCode::Space,
+                    key: Key::Named(Named::Space),
                     ..
                 }),
                 Status::Ignored,

--- a/tutorial/producing_messages_by_mouse_events.md
+++ b/tutorial/producing_messages_by_mouse_events.md
@@ -1,23 +1,24 @@
 # Producing Messages By Mouse Events
 
-To capture events of the window, we implement [subscription](https://docs.iced.rs/iced/application/trait.Application.html#method.subscription) method in [Application](https://docs.iced.rs/iced/application/trait.Application.html).
-This method returns [Subscription](https://docs.iced.rs/iced/struct.Subscription.html) struct, which allows us to specify how to handle events.
-We can use [events_with](https://docs.rs/iced/latest/iced/subscription/fn.events_with.html) function to construct a [Subscription](https://docs.iced.rs/iced/struct.Subscription.html).
-The [events_with](https://docs.rs/iced/latest/iced/subscription/fn.events_with.html) function takes a function as its input.
-The input function takes two parameters, [Event](https://docs.iced.rs/iced/event/enum.Event.html) and [Status](https://docs.iced.rs/iced/event/enum.Status.html), and returns [Option](https://doc.rust-lang.org/std/option/enum.Option.html)\<`MyAppMessage`>, which means this function is capable of transforming [Event](https://docs.iced.rs/iced/event/enum.Event.html) to `MyAppMessage`.
-We then receive the transformed `MyAppMessage` in [update](https://docs.iced.rs/iced/application/trait.Application.html#tymethod.update) method.
+To capture events of the window, we implement [subscription](https://docs.rs/iced/0.12.1/iced/application/trait.Application.html#method.subscription) method in [Application](https://docs.rs/iced/0.12.1/iced/application/trait.Application.html).
+This method returns [Subscription](https://docs.rs/iced/0.12.1/iced/struct.Subscription.html) struct, which allows us to specify how to handle events.
+We can use [listen_with](https://docs.rs/iced/0.12.1/iced/event/fn.listen_with.html) function to construct a [Subscription](https://docs.rs/iced/0.12.1/iced/struct.Subscription.html).
+The [listen_with](https://docs.rs/iced/0.12.1/iced/event/fn.listen_with.html) function takes a function as its input.
+The input function takes two parameters, [Event](https://docs.rs/iced/0.12.1/iced/event/enum.Event.html) and [Status](https://docs.rs/iced/0.12.1/iced/event/enum.Status.html), and returns [Option](https://doc.rust-lang.org/std/option/enum.Option.html)\<`MyAppMessage`>, which means this function is capable of transforming [Event](https://docs.rs/iced/0.12.1/iced/event/enum.Event.html) to `MyAppMessage`.
+We then receive the transformed `MyAppMessage` in [update](https://docs.rs/iced/0.12.1/iced/application/trait.Application.html#tymethod.update) method.
 
-In the input function, we only care about ignored events (i.e., events that is not handled by widgets) by checking if [Status](https://docs.iced.rs/iced/widget/canvas/event/enum.Status.html) is [Status::Ignored](https://docs.iced.rs/iced/widget/canvas/event/enum.Status.html#variant.Ignored).
+In the input function, we only care about ignored events (i.e., events that is not handled by widgets) by checking if [Status](https://docs.rs/iced/0.12.1/iced/widget/canvas/event/enum.Status.html) is [Status::Ignored](https://docs.rs/iced/0.12.1/iced/widget/canvas/event/enum.Status.html#variant.Ignored).
 
-In this tutorial, we capture [Event::Mouse(...)](https://docs.iced.rs/iced/enum.Event.html#variant.Mouse) and [Event::Touch(...)](https://docs.iced.rs/iced/enum.Event.html#variant.Touch) and produce messages.
-
-Note: [events_with](https://docs.rs/iced/latest/iced/subscription/fn.events_with.html) will be deprecated.
-If you cannot find this function, try using [listen_with](https://docs.iced.rs/iced/event/fn.listen_with.html).
+In this tutorial, we capture [Event::Mouse(...)](https://docs.rs/iced/0.12.1/iced/enum.Event.html#variant.Mouse) and [Event::Touch(...)](https://docs.rs/iced/0.12.1/iced/enum.Event.html#variant.Touch) and produce messages.
 
 ```rust
 use iced::{
-    event::Status, executor, mouse::Event::CursorMoved, subscription, touch::Event::FingerMoved,
-    widget::text, Application, Event, Point, Settings,
+    event::{self, Event, Status},
+    executor,
+    mouse::Event::CursorMoved,
+    touch::Event::FingerMoved,
+    widget::text,
+    Application, Point, Settings,
 };
 
 fn main() -> iced::Result {
@@ -64,7 +65,7 @@ impl Application for MyApp {
     }
 
     fn subscription(&self) -> iced::Subscription<Self::Message> {
-        subscription::events_with(|event, status| match (event, status) {
+        event::listen_with(|event, status| match (event, status) {
             (Event::Mouse(CursorMoved { position }), Status::Ignored)
             | (Event::Touch(FingerMoved { position, .. }), Status::Ignored) => {
                 Some(MyAppMessage::PointUpdated(position))

--- a/tutorial/producing_messages_by_timers.md
+++ b/tutorial/producing_messages_by_timers.md
@@ -1,7 +1,7 @@
 # Producing Messages By Timers
 
-To use build-in timers, we need to enable one of the following features: [tokio](https://docs.rs/crate/iced/latest/features#tokio), [async-std](https://docs.rs/crate/iced/latest/features#async-std), or [smol](https://docs.rs/crate/iced/latest/features#smol).
-In this tutorial, we use [async-std](https://docs.rs/crate/iced/latest/features#async-std) feature.
+To use build-in timers, we need to enable one of the following features: [tokio](https://docs.rs/crate/iced/0.12.1/features#tokio), [async-std](https://docs.rs/crate/iced/0.12.1/features#async-std), or [smol](https://docs.rs/crate/iced/0.12.1/features#smol).
+In this tutorial, we use [async-std](https://docs.rs/crate/iced/0.12.1/features#async-std) feature.
 The `Cargo.toml` should look like this:
 
 ```toml
@@ -9,10 +9,10 @@ The `Cargo.toml` should look like this:
 iced = { version = "0.10.0", features = ["async-std"] }
 ```
 
-We use [time::every](https://docs.iced.rs/iced/time/fn.every.html) function to obtain [Subscription](https://docs.iced.rs/iced/struct.Subscription.html)\<[Instant](https://docs.iced.rs/iced/time/struct.Instant.html)> struct.
-Then we map the struct to [Subscription](https://docs.iced.rs/iced/struct.Subscription.html)\<`MyAppMessage`> by [Subscription::map](https://docs.iced.rs/iced/struct.Subscription.html#method.map) method.
-The result will be returned in the [subscription](https://docs.iced.rs/iced/application/trait.Application.html#method.subscription) method of [Application](https://docs.iced.rs/iced/application/trait.Application.html).
-The corresponding `MyAppMessage` will be received in the [update](https://docs.iced.rs/iced/application/trait.Application.html#tymethod.update) method.
+We use [time::every](https://docs.rs/iced/0.12.1/iced/time/fn.every.html) function to obtain [Subscription](https://docs.rs/iced/0.12.1/iced/struct.Subscription.html)\<[Instant](https://docs.rs/iced/0.12.1/iced/time/struct.Instant.html)> struct.
+Then we map the struct to [Subscription](https://docs.rs/iced/0.12.1/iced/struct.Subscription.html)\<`MyAppMessage`> by [Subscription::map](https://docs.rs/iced/0.12.1/iced/struct.Subscription.html#method.map) method.
+The result will be returned in the [subscription](https://docs.rs/iced/0.12.1/iced/application/trait.Application.html#method.subscription) method of [Application](https://docs.rs/iced/0.12.1/iced/application/trait.Application.html).
+The corresponding `MyAppMessage` will be received in the [update](https://docs.rs/iced/0.12.1/iced/application/trait.Application.html#tymethod.update) method.
 
 ```rust
 use iced::{
@@ -56,7 +56,7 @@ impl Application for MyApp {
         Command::none()
     }
 
-    fn view(&self) -> iced::Element<'_, Self::Message, iced::Renderer<Self::Theme>> {
+    fn view(&self) -> iced::Element<'_, Self::Message> {
         text(self.seconds).into()
     }
 

--- a/tutorial/producing_widget_messages.md
+++ b/tutorial/producing_widget_messages.md
@@ -1,8 +1,8 @@
 # Producing Widget Messages
 
-Our custom widgets are able to send [Message](https://docs.rs/iced/latest/iced/trait.Sandbox.html#associatedtype.Message).
+Our custom widgets are able to send [Message](https://docs.rs/iced/0.12.1/iced/trait.Sandbox.html#associatedtype.Message).
 
-To do so, we need to store the [Message](https://docs.rs/iced/latest/iced/trait.Sandbox.html#associatedtype.Message) we are going to send in the widget.
+To do so, we need to store the [Message](https://docs.rs/iced/0.12.1/iced/trait.Sandbox.html#associatedtype.Message) we are going to send in the widget.
 
 ```rust
 struct MyWidget<Message> {
@@ -16,7 +16,7 @@ impl<Message> MyWidget<Message> {
 }
 ```
 
-We use a generic type `Message` for `MyWidget`, so that the sent `pressed_message` in `MyWidget` will match the associated type [Message](https://docs.rs/iced/latest/iced/trait.Sandbox.html#associatedtype.Message) of [Sandbox](https://docs.rs/iced/latest/iced/trait.Sandbox.html).
+We use a generic type `Message` for `MyWidget`, so that the sent `pressed_message` in `MyWidget` will match the associated type [Message](https://docs.rs/iced/0.12.1/iced/trait.Sandbox.html#associatedtype.Message) of [Sandbox](https://docs.rs/iced/0.12.1/iced/trait.Sandbox.html).
 
 The message `pressed_message` will be sent when the widget is pressed.
 
@@ -49,7 +49,7 @@ fn on_event(
 We use `shell.publish(self.pressed_message.clone())` to send `pressed_message` to our app.
 To ensure the mouse pressed event happens within the range of the widget, we use `cursor.is_over(layout.bounds())` to check the mouse position and match the `event` to `Event::Mouse(mouse::Event::ButtonPressed(_))` to check the mouse button state.
 
-Finally, we pass our [Message](https://docs.rs/iced/latest/iced/trait.Sandbox.html#associatedtype.Message) to the widget.
+Finally, we pass our [Message](https://docs.rs/iced/0.12.1/iced/trait.Sandbox.html#associatedtype.Message) to the widget.
 
 ```rust
 #[derive(Debug, Clone)]
@@ -82,14 +82,14 @@ The full code is as follows:
 ```rust
 use iced::{
     advanced::{
+        graphics::core::event,
         layout, mouse,
         renderer::{self, Quad},
         widget::Tree,
         Clipboard, Layout, Shell, Widget,
     },
-    event,
     widget::{column, container, text},
-    Alignment, Color, Element, Event, Length, Rectangle, Sandbox, Settings,
+    Alignment, Border, Color, Element, Event, Length, Rectangle, Sandbox, Settings, Shadow, Size, Theme,
 };
 
 fn main() -> iced::Result {
@@ -124,9 +124,9 @@ impl Sandbox for MyApp {
 
     fn view(&self) -> iced::Element<'_, Self::Message> {
         container(
-            column![MyWidget::new(MyMessage::MyWidgetPressed), text(self.count),]
+            column![MyWidget::new(MyMessage::MyWidgetPressed), text(self.count)]
                 .spacing(20)
-                .align_items(Alignment::Center),
+                .align_items(iced::Alignment::Center),
         )
         .width(Length::Fill)
         .height(Length::Fill)
@@ -146,20 +146,24 @@ impl<Message> MyWidget<Message> {
     }
 }
 
-impl<Message, Renderer> Widget<Message, Renderer> for MyWidget<Message>
+impl<Message, Renderer> Widget<Message, Theme, Renderer> for MyWidget<Message>
 where
-    Message: Clone,
     Renderer: iced::advanced::Renderer,
+    Message: Clone,
 {
-    fn width(&self) -> Length {
-        Length::Shrink
+    fn size(&self) -> Size<Length> {
+        Size {
+            width: Length::Shrink,
+            height: Length::Shrink,
+        }
     }
 
-    fn height(&self) -> Length {
-        Length::Shrink
-    }
-
-    fn layout(&self, _renderer: &Renderer, _limits: &layout::Limits) -> layout::Node {
+    fn layout(
+        &self,
+        _tree: &mut Tree,
+        _renderer: &Renderer,
+        _limits: &layout::Limits,
+    ) -> layout::Node {
         layout::Node::new([100, 100].into())
     }
 
@@ -167,7 +171,7 @@ where
         &self,
         _state: &Tree,
         renderer: &mut Renderer,
-        _theme: &Renderer::Theme,
+        _theme: &Theme,
         _style: &renderer::Style,
         layout: Layout<'_>,
         _cursor: mouse::Cursor,
@@ -176,9 +180,12 @@ where
         renderer.fill_quad(
             Quad {
                 bounds: layout.bounds(),
-                border_radius: 10.0.into(),
-                border_width: 1.0,
-                border_color: Color::from_rgb(0.6, 0.8, 1.0),
+                border: Border {
+                    color: Color::from_rgb(0.6, 0.8, 1.0),
+                    width: 1.0,
+                    radius: 10.0.into(),
+                },
+                shadow: Shadow::default(),
             },
             Color::from_rgb(0.0, 0.2, 0.4),
         );
@@ -209,7 +216,7 @@ where
     }
 }
 
-impl<'a, Message, Renderer> From<MyWidget<Message>> for Element<'a, Message, Renderer>
+impl<'a, Message, Renderer> From<MyWidget<Message>> for Element<'a, Message, Theme, Renderer>
 where
     Message: 'a + Clone,
     Renderer: iced::advanced::Renderer,

--- a/tutorial/progressbar.md
+++ b/tutorial/progressbar.md
@@ -1,6 +1,6 @@
 # ProgressBar
 
-The [ProgressBar](https://docs.iced.rs/iced/widget/progress_bar/struct.ProgressBar.html) widget represents a value in a given range.
+The [ProgressBar](https://docs.rs/iced/0.12.1/iced/widget/progress_bar/struct.ProgressBar.html) widget represents a value in a given range.
 It has two methods of constructions.
 
 ```rust

--- a/tutorial/radio.md
+++ b/tutorial/radio.md
@@ -1,6 +1,6 @@
 # Radio
 
-The [Radio](https://docs.iced.rs/iced/widget/radio/struct.Radio.html) widget represents a choice among multiple values.
+The [Radio](https://docs.rs/iced/0.12.1/iced/widget/radio/struct.Radio.html) widget represents a choice among multiple values.
 It has two methods of constructions.
 It supports reactions to clicking and touching.
 It is able to change styles of the button and the text.

--- a/tutorial/row.md
+++ b/tutorial/row.md
@@ -1,6 +1,6 @@
 # Row
 
-Similar to [Column](https://docs.rs/iced/latest/iced/widget/struct.Column.html), [Row](https://docs.rs/iced/latest/iced/widget/struct.Row.html) helps us placing widgets horizontally.
+Similar to [Column](https://docs.rs/iced/0.12.1/iced/widget/struct.Column.html), [Row](https://docs.rs/iced/0.12.1/iced/widget/struct.Row.html) helps us placing widgets horizontally.
 It can leave some space between its boundary and its inner content.
 It can also add spaces among its inner widgets.
 The inner widgets can be aligned top, middle or bottom.

--- a/tutorial/rule.md
+++ b/tutorial/rule.md
@@ -1,6 +1,6 @@
 # Rule
 
-The [Rule](https://docs.iced.rs/iced/widget/rule/struct.Rule.html) widget is a horizontal (or vertical) line for separating widgets clearly.
+The [Rule](https://docs.rs/iced/0.12.1/iced/widget/rule/struct.Rule.html) widget is a horizontal (or vertical) line for separating widgets clearly.
 It has two methods of constructions.
 We can change the space around it.
 The widget can be set to be either horizontal or vertical.

--- a/tutorial/scrollable.md
+++ b/tutorial/scrollable.md
@@ -1,7 +1,7 @@
 # Scrollable
 
 When there are too many widgets, they may go beyond the boundary of the window.
-[Scrollable](https://docs.rs/iced/latest/iced/widget/scrollable/struct.Scrollable.html) provides an infinite space that widgets can be navigated by scroll bars.
+[Scrollable](https://docs.rs/iced/0.12.1/iced/widget/scrollable/struct.Scrollable.html) provides an infinite space that widgets can be navigated by scroll bars.
 The scroll bars can be vertical, horizontal or both.
 When the scroll bars are changed, we can also receive their scroll positions and update other widgets.
 
@@ -51,20 +51,17 @@ impl Sandbox for MyApp {
         let long_vertical_texts = column(
             (0..10)
                 .map(|i| text(format!("{} vertical scrollable", i + 1)).into())
-                .collect(),
         );
         let long_horizontal_texts = row((0..10)
             .map(|i| text(format!("{} horizontal scrollable  ", i + 1)).into())
-            .collect());
+        );
         let long_both_texts = column(
             (0..10)
                 .map(|i| text(format!("{} vertical and horizontal scrollable", i + 1)).into())
-                .collect(),
         );
         let long_both_texts_2 = column(
             (0..10)
                 .map(|i| text(format!("{} vertical and horizontal scrollable", i + 1)).into())
-                .collect(),
         );
 
         column![
@@ -103,7 +100,7 @@ impl Sandbox for MyApp {
 
 ![Scrollable](./pic/scrollable.png)
 
-Instead of using [Scrollable::new](https://docs.rs/iced/latest/iced/widget/scrollable/struct.Scrollable.html#method.new), we can also use the [scrollable](https://docs.rs/iced/latest/iced/widget/fn.scrollable.html) function.
+Instead of using [Scrollable::new](https://docs.rs/iced/0.12.1/iced/widget/scrollable/struct.Scrollable.html#method.new), we can also use the [scrollable](https://docs.rs/iced/0.12.1/iced/widget/fn.scrollable.html) function.
 
 :arrow_right:  Next: [Changing Themes](./changing_themes.md)
 

--- a/tutorial/setting_up.md
+++ b/tutorial/setting_up.md
@@ -19,14 +19,14 @@ You should see the dependency in the end of `Cargo.toml` file.
 
 ```toml
 [dependencies]
-iced = "0.10.0"
+iced = "0.12.1"
 ```
 
 Note: If you encounter `WGPU Error`, you can disable `wgpu` in `Cargo.toml` file.
 
 ```toml
 [dependencies]
-iced = { version = "0.10.0", default-features = false }
+iced = { version = "0.12.1"", default-features = false }
 ```
 
 :arrow_right:  Next: [First App - Hello World!](./first_app.md)

--- a/tutorial/slider.md
+++ b/tutorial/slider.md
@@ -1,6 +1,6 @@
 # Slider And VerticalSlider
 
-The [Slider](https://docs.iced.rs/iced/widget/slider/struct.Slider.html) widget represents a chosen value in a given range.
+The [Slider](https://docs.rs/iced/0.12.1/iced/widget/slider/struct.Slider.html) widget represents a chosen value in a given range.
 It has two methods of constructions.
 It supports reactions to mouse pressing/releasing and touching.
 The selected value can be snapped to a given step.
@@ -73,7 +73,7 @@ impl Sandbox for MyApp {
             text("Shorter parameter"),
             slider(0..=100, self.value4, MyAppMessage::Update4),
             text("Different step"),
-            slider(0..=100, self.value5, MyAppMessage::Update5).step(10),
+            slider(0..=100, self.value5, MyAppMessage::Update5).step(10u32),
             text(format!("React to mouse release: {}", self.released_value_6)),
             slider(0..=100, self.value6, MyAppMessage::Update6).on_release(MyAppMessage::Release6),
             text("Vertical slider"),

--- a/tutorial/space.md
+++ b/tutorial/space.md
@@ -1,6 +1,6 @@
 # Space
 
-[Space](https://docs.rs/iced/latest/iced/widget/space/struct.Space.html) is a convenient widget that helps us laying out our widgets.
+[Space](https://docs.rs/iced/0.12.1/iced/widget/space/struct.Space.html) is a convenient widget that helps us laying out our widgets.
 It is an empty widget that occupies a space.
 It has several constructions to help us allocating spaces horizontally, vertically or both.
 
@@ -45,16 +45,16 @@ impl Sandbox for MyApp {
 
             row![
                 button("Horizontal space 3A"),
-                horizontal_space(50),
+                horizontal_space(),
                 button("Horizontal space 3B"),
             ],
 
             button("Vertical space 1A"),
             Space::with_height(50),
             button("Vertical space 1B"),
-            
+            Space::with_height(Length::Fill),
             button("Vertical space 2A"),
-            vertical_space(50),
+            vertical_space(),
             button("Vertical space 2B"),
             
             button("Diagonal space A"),

--- a/tutorial/svg.md
+++ b/tutorial/svg.md
@@ -1,15 +1,15 @@
 # Svg
 
-The [Svg](https://docs.iced.rs/iced/widget/svg/struct.Svg.html) widget is able to display an [SVG](https://en.wikipedia.org/wiki/SVG) image.
+The [Svg](https://docs.rs/iced/0.12.1/iced/widget/svg/struct.Svg.html) widget is able to display an [SVG](https://en.wikipedia.org/wiki/SVG) image.
 It has two methods of constructions.
 We can set how to fit the image content into the widget bounds.
 
-To use the widget, we have to enable the [svg](https://docs.rs/crate/iced/latest/features#svg) feature.
+To use the widget, we have to enable the [svg](https://docs.rs/iced/0.12.1/iced/latest/features#svg) feature.
 The `Cargo.toml` dependencies should look like this:
 
 ```toml
 [dependencies]
-iced = { version = "0.10.0", features = ["svg"] }
+iced = { version = "0.12.1", features = ["svg"] }
 ```
 
 Let's add an [SVG](https://en.wikipedia.org/wiki/SVG) image named `pic.svg` into the project root directory, i.e., the image has the path `my_project/pic.svg` where `my_project` is the name of our project.

--- a/tutorial/taking_any_children.md
+++ b/tutorial/taking_any_children.md
@@ -1,86 +1,101 @@
 # Taking Any Children
 
-Since all [Widget](https://docs.rs/iced/latest/iced/advanced/widget/trait.Widget.html) can be transformed to [Element](https://docs.rs/iced_core/0.12.1/iced_core/struct.Element.html), our custom widget is able to take any [Widget](https://docs.rs/iced/latest/iced/advanced/widget/trait.Widget.html) as its children.
+Since all [Widget](https://docs.rs/iced/0.12.1/iced/advanced/widget/trait.Widget.html) can be transformed to [Element](https://docs.rs/iced_core/0.12.1/iced_core/struct.Element.html), our custom widget is able to take any [Widget](https://docs.rs/iced/0.12.1/iced/advanced/widget/trait.Widget.html) as its children.
 
 This time, our `MyWidgetOuter` will take an [Element](https://docs.rs/iced_core/0.12.1/iced_core/struct.Element.html) as its inner widget when it is initialized.
 
 ```rust
 struct MyWidgetOuter<'a, Message, Renderer> {
-    inner_widget: Element<'a, Message, Renderer>,
+    inner_widget: Element<'a, Message, Theme, Renderer>,
 }
 
 impl<'a, Message, Renderer> MyWidgetOuter<'a, Message, Renderer>
 where
     Renderer: iced::advanced::Renderer,
 {
-    fn new(inner_widget: Element<'a, Message, Renderer>) -> Self {
+    fn new(inner_widget: Element<'a, Message, Theme, Renderer>) -> Self {
         Self { inner_widget }
     }
 }
 ```
 
-When we draw or layout the `inner_widget`, we will use its methods from [Widget](https://docs.rs/iced/latest/iced/advanced/widget/trait.Widget.html).
+When we draw or layout the `inner_widget`, we will use its methods from [Widget](https://docs.rs/iced/0.12.1/iced/advanced/widget/trait.Widget.html).
 Yet, the `inner_widget` is of type [Element](https://docs.rs/iced_core/0.12.1/iced_core/struct.Element.html).
-So, we have to cast it as [Widget](https://docs.rs/iced/latest/iced/advanced/widget/trait.Widget.html) by the [as_widget](https://docs.rs/iced_core/0.12.1/iced_core/struct.Element.html#method.as_widget) method.
+So, we have to cast it as [Widget](https://docs.rs/iced/0.12.1/iced/advanced/widget/trait.Widget.html) by the [as_widget](https://docs.rs/iced_core/0.12.1/iced_core/struct.Element.html#method.as_widget) method.
 
 ```rust
-fn layout(&self, renderer: &Renderer, limits: &layout::Limits) -> layout::Node {
-    let mut child_node = self.inner_widget.as_widget().layout(renderer, limits);
+fn layout(
+	&self,
+	tree: &mut Tree,
+	renderer: &Renderer,
+	limits: &layout::Limits,
+) -> layout::Node {
+	let mut child_node =
+		self.inner_widget
+			.as_widget()
+			.layout(&mut tree.children[0], renderer, limits);
 
-    let size_of_this_node = child_node.size().pad(50.into());
+	let size_of_this_node = child_node.size().expand(Size::new(50., 50.));
 
-    child_node.align(Alignment::Center, Alignment::Center, size_of_this_node);
+	child_node = child_node.align(Alignment::Center, Alignment::Center, size_of_this_node);
 
-    layout::Node::with_children(size_of_this_node, vec![child_node])
+	layout::Node::with_children(size_of_this_node, vec![child_node])
 }
 ```
 
 In the code above, we make the size of `MyWidgetOuter` relative to its `inner_widget`.
-More precisely, we retrieve the size of `inner_widget` and [pad](https://docs.rs/iced_core/0.10.0/iced_core/struct.Size.html#method.pad) the size as the size of `MyWidgetOuter`.
+More precisely, we retrieve the size of `inner_widget` and [pad](https://docs.rs/iced_core/0.12.1/iced_core/struct.Size.html#method.pad) the size as the size of `MyWidgetOuter`.
 
-Then, in the [draw](https://docs.rs/iced/latest/iced/advanced/widget/trait.Widget.html#tymethod.draw) method of `MyWidgetOuter`, we also draw the `inner_widget`.
+Then, in the [draw](https://docs.rs/iced/0.12.1/iced/advanced/widget/trait.Widget.html#tymethod.draw) method of `MyWidgetOuter`, we also draw the `inner_widget`.
 
 ```rust
 fn draw(
-    &self,
-    state: &Tree,
-    renderer: &mut Renderer,
-    theme: &Renderer::Theme,
-    style: &renderer::Style,
-    layout: Layout<'_>,
-    cursor: mouse::Cursor,
-    viewport: &Rectangle,
+	&self,
+	state: &Tree,
+	renderer: &mut Renderer,
+	theme: &Theme,
+	style: &renderer::Style,
+	layout: Layout<'_>,
+	cursor: mouse::Cursor,
+	viewport: &Rectangle,
 ) {
-    renderer.fill_quad(
-        Quad {
-            bounds: layout.bounds(),
-            border_radius: 10.0.into(),
-            border_width: 1.0,
-            border_color: Color::from_rgb(0.6, 0.93, 1.0),
-        },
-        Color::from_rgb(0.0, 0.33, 0.4),
-    );
-
-    self.inner_widget.as_widget().draw(
-        &state.children[0],
-        renderer,
-        theme,
-        style,
-        layout.children().next().unwrap(),
-        cursor,
-        viewport,
-    );
+	renderer.fill_quad(
+		Quad {
+			bounds: layout.bounds(),
+			border: Border {
+				color: Color::from_rgb(0.6, 0.93, 1.0),
+				width: 1.0,
+				radius: 10.0.into(),
+			},
+			shadow: Shadow::default(),
+		},
+		Color::from_rgb(0.0, 0.33, 0.4),
+	);
+	
+	self.inner_widget.as_widget().draw(
+		&state.children[0],
+		renderer,
+		theme,
+		style,
+		layout.children().next().unwrap(),
+		cursor,
+		viewport,
+	);
 }
 ```
 
 Note that we have to pass the child state `&state.children[0]` to `inner_widget` since the anonymous widget may need the information about its state.
 
 To make the underlying system aware of the child state, we have to explicitly tell the system the existence of the child.
-Otherwise, `state.children` in [draw](https://docs.rs/iced/latest/iced/advanced/widget/trait.Widget.html#tymethod.draw) will be empty.
+Otherwise, `state.children` in [draw](https://docs.rs/iced/0.12.1/iced/advanced/widget/trait.Widget.html#tymethod.draw) will be empty.
 
 ```rust
 fn children(&self) -> Vec<Tree> {
     vec![Tree::new(self.inner_widget.as_widget())]
+}
+
+fn diff(&self, tree: &mut Tree) {
+	tree.diff_children(std::slice::from_ref(&self.inner_widget));
 }
 ```
 
@@ -95,7 +110,7 @@ use iced::{
         Layout, Widget,
     },
     widget::{button, container},
-    Alignment, Color, Element, Length, Rectangle, Sandbox, Settings,
+    Alignment, Border, Color, Element, Length, Rectangle, Sandbox, Settings, Shadow, Size, Theme,
 };
 
 fn main() -> iced::Result {
@@ -128,36 +143,47 @@ impl Sandbox for MyApp {
 }
 
 struct MyWidgetOuter<'a, Message, Renderer> {
-    inner_widget: Element<'a, Message, Renderer>,
+    inner_widget: Element<'a, Message, Theme, Renderer>,
 }
 
 impl<'a, Message, Renderer> MyWidgetOuter<'a, Message, Renderer>
 where
     Renderer: iced::advanced::Renderer,
 {
-    fn new(inner_widget: Element<'a, Message, Renderer>) -> Self {
+    fn new(inner_widget: Element<'a, Message, Theme, Renderer>) -> Self {
         Self { inner_widget }
     }
 }
 
-impl<Message, Renderer> Widget<Message, Renderer> for MyWidgetOuter<'_, Message, Renderer>
+impl<Message, Renderer> Widget<Message, Theme, Renderer> for MyWidgetOuter<'_, Message, Renderer>
 where
     Renderer: iced::advanced::Renderer,
 {
-    fn width(&self) -> Length {
-        Length::Shrink
+    fn size(&self) -> Size<Length> {
+        Size {
+            width: Length::Shrink,
+            height: Length::Shrink,
+        }
     }
 
-    fn height(&self) -> Length {
-        Length::Shrink
+    fn diff(&self, tree: &mut Tree) {
+        tree.diff_children(std::slice::from_ref(&self.inner_widget));
     }
 
-    fn layout(&self, renderer: &Renderer, limits: &layout::Limits) -> layout::Node {
-        let mut child_node = self.inner_widget.as_widget().layout(renderer, limits);
+    fn layout(
+        &self,
+        tree: &mut Tree,
+        renderer: &Renderer,
+        limits: &layout::Limits,
+    ) -> layout::Node {
+        let mut child_node =
+            self.inner_widget
+                .as_widget()
+                .layout(&mut tree.children[0], renderer, limits);
 
-        let size_of_this_node = child_node.size().pad(50.into());
+        let size_of_this_node = child_node.size().expand(Size::new(50., 50.));
 
-        child_node.align(Alignment::Center, Alignment::Center, size_of_this_node);
+        child_node = child_node.align(Alignment::Center, Alignment::Center, size_of_this_node);
 
         layout::Node::with_children(size_of_this_node, vec![child_node])
     }
@@ -170,7 +196,7 @@ where
         &self,
         state: &Tree,
         renderer: &mut Renderer,
-        theme: &Renderer::Theme,
+        theme: &Theme,
         style: &renderer::Style,
         layout: Layout<'_>,
         cursor: mouse::Cursor,
@@ -179,9 +205,12 @@ where
         renderer.fill_quad(
             Quad {
                 bounds: layout.bounds(),
-                border_radius: 10.0.into(),
-                border_width: 1.0,
-                border_color: Color::from_rgb(0.6, 0.93, 1.0),
+                border: Border {
+                    color: Color::from_rgb(0.6, 0.93, 1.0),
+                    width: 1.0,
+                    radius: 10.0.into(),
+                },
+                shadow: Shadow::default(),
             },
             Color::from_rgb(0.0, 0.33, 0.4),
         );
@@ -199,7 +228,7 @@ where
 }
 
 impl<'a, Message, Renderer> From<MyWidgetOuter<'a, Message, Renderer>>
-    for Element<'a, Message, Renderer>
+    for Element<'a, Message, Theme, Renderer>
 where
     Message: 'a,
     Renderer: iced::advanced::Renderer + 'a,

--- a/tutorial/text.md
+++ b/tutorial/text.md
@@ -1,6 +1,6 @@
 # Text
 
-The [Text](https://docs.iced.rs/iced/widget/type.Text.html) widget is able to display texts.
+The [Text](https://docs.rs/iced/0.12.1/ced/widget/type.Text.html) widget is able to display texts.
 It has three methods of constructions.
 It is able to change the font, the size of the font, and display special characters.
 The text inside the widget can be horizontally or vertically centered.

--- a/tutorial/text_input.md
+++ b/tutorial/text_input.md
@@ -1,8 +1,8 @@
 # TextInput
 
-The [TextInput](https://docs.rs/iced/latest/iced/widget/struct.TextInput.html) widget let users to input texts.
+The [TextInput](https://docs.rs/iced/0.12.1/iced/latest/iced/widget/struct.TextInput.html) widget let users to input texts.
 It has two methods of constructions.
-If the [on_input](https://docs.rs/iced/latest/iced/widget/struct.TextInput.html#method.on_input) method is set, it is enabled, and is disabled otherwise.
+If the [on_input](https://docs.rs/iced/0.12.1/iced/widget/struct.TextInput.html#method.on_input) method is set, it is enabled, and is disabled otherwise.
 It supports reactions to pasting texts or keyboard submissions.
 It is able to change fonts and text sizes.
 We can add padding around the text inside.
@@ -96,7 +96,7 @@ impl Sandbox for MyApp {
                 .on_submit(MyAppMessage::Submit6),
             text(self.info6.as_str()),
             text_input("Password", self.text7.as_str())
-                .password()
+                .secure(true)
                 .on_input(MyAppMessage::Update7),
             text_input("Different font", "").font(Font {
                 family: Family::Fantasy,

--- a/tutorial/toggler.md
+++ b/tutorial/toggler.md
@@ -1,6 +1,6 @@
 # Toggler
 
-The [Toggler](https://docs.iced.rs/iced/widget/toggler/struct.Toggler.html) widget represents a boolean value.
+The [Toggler](https://docs.rs/iced/0.12.1/iced/widget/toggler/struct.Toggler.html) widget represents a boolean value.
 (Note, it appears on the right of its text.)
 It has two methods of constructions.
 It supports reactions to clicking and touching.

--- a/tutorial/tooltip.md
+++ b/tutorial/tooltip.md
@@ -1,6 +1,6 @@
 # Tooltip
 
-The [Tooltip](https://docs.iced.rs/iced/widget/tooltip/struct.Tooltip.html) widget displays a text when the mouse is over a specified widget.
+The [Tooltip](https://docs.rs/iced/0.12.1/iced/widget/tooltip/struct.Tooltip.html) widget displays a text when the mouse is over a specified widget.
 It has two methods of constructions.
 It is able to change styles of the text.
 We can add padding around the text inside.
@@ -47,21 +47,6 @@ impl Sandbox for MyApp {
             ),
             tooltip(
                 button("Mouseover to see the tooltip"),
-                "Different font",
-                Position::Right
-            )
-            .font(Font {
-                family: Family::Fantasy,
-                ..Font::DEFAULT
-            }),
-            tooltip(
-                button("Mouseover to see the tooltip"),
-                "Larger text",
-                Position::Right
-            )
-            .size(24),
-            tooltip(
-                button("Mouseover to see the tooltip"),
                 "With padding",
                 Position::Right
             )
@@ -78,6 +63,11 @@ impl Sandbox for MyApp {
                 Position::Right
             )
             .snap_within_viewport(false),
+            tooltip(
+                button("Mouseover to see the tooltip"),
+                "Follow the cursor",
+                Position::FollowCursor
+            )
         ]
         .into()
     }

--- a/tutorial/updating_widgets_from_events.md
+++ b/tutorial/updating_widgets_from_events.md
@@ -1,9 +1,9 @@
 # Updating Widgets From Events
 
 Sometimes, we would like our widgets to handle their states by themselves.
-For example, a widget might change its states when receiving an [Event](https://docs.rs/iced/latest/iced/event/enum.Event.html).
+For example, a widget might change its states when receiving an [Event](https://docs.rs/iced/0.12.1/iced/event/enum.Event.html).
 
-To do so, we implement the [on_event](https://docs.rs/iced/latest/iced/advanced/widget/trait.Widget.html#method.on_event) method of [Widget](https://docs.rs/iced/latest/iced/advanced/widget/trait.Widget.html).
+To do so, we implement the [on_event](https://docs.rs/iced/0.12.1/iced/advanced/widget/trait.Widget.html#method.on_event) method of [Widget](https://docs.rs/iced/0.12.1/iced/advanced/widget/trait.Widget.html).
 
 ```rust
 fn on_event(
@@ -18,8 +18,8 @@ fn on_event(
     _viewport: &Rectangle,
 ) -> event::Status {
     match event {
-        Event::Keyboard(keyboard::Event::KeyPressed {
-            key_code: KeyCode::Space,
+		Event::Keyboard(keyboard::Event::KeyPressed {
+			key: keyboard::Key::Named(Named::Space),
             ..
         }) => {
             self.highlight = !self.highlight;
@@ -32,8 +32,8 @@ fn on_event(
 
 Our widget changes its `highlight` field every time when the space bar is pressed.
 
-If the [Event](https://docs.rs/iced/latest/iced/event/enum.Event.html) passed to the [on_event](https://docs.rs/iced/latest/iced/advanced/widget/trait.Widget.html#method.on_event) method is what the widget needs, we return [Status::Captured](https://docs.rs/iced/latest/iced/event/enum.Status.html#variant.Captured).
-Otherwise, we return [Status::Ignored](https://docs.rs/iced/latest/iced/event/enum.Status.html#variant.Ignored) to tell the system the event can be used by other widgets.
+If the [Event](https://docs.rs/iced/0.12.1/iced/event/enum.Event.html) passed to the [on_event](https://docs.rs/iced/0.12.1/iced/advanced/widget/trait.Widget.html#method.on_event) method is what the widget needs, we return [Status::Captured](https://docs.rs/iced/0.12.1/iced/event/enum.Status.html#variant.Captured).
+Otherwise, we return [Status::Ignored](https://docs.rs/iced/0.12.1/iced/event/enum.Status.html#variant.Ignored) to tell the system the event can be used by other widgets.
 
 Since our widget maintains its own state, we do not need to pass the state from our app.
 
@@ -54,15 +54,15 @@ The full code is as follows:
 ```rust
 use iced::{
     advanced::{
+        graphics::core::event,
         layout, mouse,
         renderer::{self, Quad},
         widget::Tree,
         Clipboard, Layout, Shell, Widget,
     },
-    event,
-    keyboard::{self, KeyCode},
+    keyboard::{self, key::Named},
     widget::container,
-    Color, Element, Event, Length, Rectangle, Sandbox, Settings,
+    Border, Color, Element, Event, Length, Rectangle, Sandbox, Settings, Shadow, Size, Theme,
 };
 
 fn main() -> iced::Result {
@@ -104,19 +104,23 @@ impl MyWidget {
     }
 }
 
-impl<Message, Renderer> Widget<Message, Renderer> for MyWidget
+impl<Message, Renderer> Widget<Message, Theme, Renderer> for MyWidget
 where
     Renderer: iced::advanced::Renderer,
 {
-    fn width(&self) -> Length {
-        Length::Shrink
+    fn size(&self) -> Size<Length> {
+        Size {
+            width: Length::Shrink,
+            height: Length::Shrink,
+        }
     }
 
-    fn height(&self) -> Length {
-        Length::Shrink
-    }
-
-    fn layout(&self, _renderer: &Renderer, _limits: &layout::Limits) -> layout::Node {
+    fn layout(
+        &self,
+        _tree: &mut Tree,
+        _renderer: &Renderer,
+        _limits: &layout::Limits,
+    ) -> layout::Node {
         layout::Node::new([100, 100].into())
     }
 
@@ -124,7 +128,7 @@ where
         &self,
         _state: &Tree,
         renderer: &mut Renderer,
-        _theme: &Renderer::Theme,
+        _theme: &Theme,
         _style: &renderer::Style,
         layout: Layout<'_>,
         _cursor: mouse::Cursor,
@@ -133,9 +137,12 @@ where
         renderer.fill_quad(
             Quad {
                 bounds: layout.bounds(),
-                border_radius: 10.0.into(),
-                border_width: 1.0,
-                border_color: Color::from_rgb(0.6, 0.8, 1.0),
+                border: Border {
+                    color: Color::from_rgb(0.6, 0.8, 1.0),
+                    width: 1.0,
+                    radius: 10.0.into(),
+                },
+                shadow: Shadow::default(),
             },
             if self.highlight {
                 Color::from_rgb(0.6, 0.8, 1.0)
@@ -158,7 +165,7 @@ where
     ) -> event::Status {
         match event {
             Event::Keyboard(keyboard::Event::KeyPressed {
-                key_code: KeyCode::Space,
+                key: keyboard::Key::Named(Named::Space),
                 ..
             }) => {
                 self.highlight = !self.highlight;
@@ -169,7 +176,7 @@ where
     }
 }
 
-impl<'a, Message, Renderer> From<MyWidget> for Element<'a, Message, Renderer>
+impl<'a, Message, Renderer> From<MyWidget> for Element<'a, Message, Theme, Renderer>
 where
     Renderer: iced::advanced::Renderer,
 {

--- a/tutorial/updating_widgets_from_outside.md
+++ b/tutorial/updating_widgets_from_outside.md
@@ -8,14 +8,14 @@ struct MyWidget {
 }
 ```
 
-We use the `highlight` variable to change the color of our widget in the [draw](https://docs.rs/iced/latest/iced/advanced/widget/trait.Widget.html#tymethod.draw) method.
+We use the `highlight` variable to change the color of our widget in the [draw](https://docs.rs/iced/0.12.1/iced/advanced/widget/trait.Widget.html#tymethod.draw) method.
 
 ```rust
 fn draw(
     &self,
     _state: &Tree,
     renderer: &mut Renderer,
-    _theme: &Renderer::Theme,
+    _theme: &Theme,
     _style: &renderer::Style,
     layout: Layout<'_>,
     _cursor: mouse::Cursor,
@@ -24,15 +24,18 @@ fn draw(
     renderer.fill_quad(
         Quad {
             bounds: layout.bounds(),
-            border_radius: 10.0.into(),
-            border_width: 1.0,
-            border_color: Color::from_rgb(0.6, 0.8, 1.0),
-        },
-        if self.highlight {
-            Color::from_rgb(0.6, 0.8, 1.0)
-        } else {
-            Color::from_rgb(0.0, 0.2, 0.4)
-        },
+			border: Border {
+				color: Color::from_rgb(0.6, 0.8, 1.0),
+				width: 1.0,
+				radius: 10.0.into(),
+				},
+			shadow: Shadow::default(),
+		},
+		if self.highlight {
+			Color::from_rgb(0.6, 0.8, 1.0)
+		} else {
+			Color::from_rgb(0.0, 0.2, 0.4)
+		},
     );
 }
 ```
@@ -49,7 +52,7 @@ impl MyWidget {
 }
 ```
 
-Then, we initialize `MyWidget` in the [view](https://docs.rs/iced/latest/iced/trait.Sandbox.html#tymethod.view) method of [Sandbox](https://docs.rs/iced/latest/iced/trait.Sandbox.html) with an input value for the `highlight` variable.
+Then, we initialize `MyWidget` in the [view](https://docs.rs/iced/0.12.1/iced/trait.Sandbox.html#tymethod.view) method of [Sandbox](https://docs.rs/iced/0.12.1/iced/trait.Sandbox.html) with an input value for the `highlight` variable.
 
 ```rust
 struct MyApp {
@@ -84,7 +87,7 @@ use iced::{
         Layout, Widget,
     },
     widget::{checkbox, column, container},
-    Color, Element, Length, Rectangle, Sandbox, Settings,
+    Border, Color, Element, Length, Rectangle, Sandbox, Settings, Shadow, Size, Theme,
 };
 
 fn main() -> iced::Result {
@@ -95,7 +98,6 @@ fn main() -> iced::Result {
 enum MyMessage {
     Highlight(bool),
 }
-
 struct MyApp {
     highlight: bool,
 }
@@ -121,7 +123,7 @@ impl Sandbox for MyApp {
         container(
             column![
                 MyWidget::new(self.highlight),
-                checkbox("Highlight", self.highlight, MyMessage::Highlight),
+                checkbox("Highlight", self.highlight).on_toggle(MyMessage::Highlight),
             ]
             .spacing(20),
         )
@@ -143,19 +145,23 @@ impl MyWidget {
     }
 }
 
-impl<Message, Renderer> Widget<Message, Renderer> for MyWidget
+impl<Message, Renderer> Widget<Message, Theme, Renderer> for MyWidget
 where
     Renderer: iced::advanced::Renderer,
 {
-    fn width(&self) -> Length {
-        Length::Shrink
+    fn size(&self) -> Size<Length> {
+        Size {
+            width: Length::Shrink,
+            height: Length::Shrink,
+        }
     }
 
-    fn height(&self) -> Length {
-        Length::Shrink
-    }
-
-    fn layout(&self, _renderer: &Renderer, _limits: &layout::Limits) -> layout::Node {
+    fn layout(
+        &self,
+        _tree: &mut Tree,
+        _renderer: &Renderer,
+        _limits: &layout::Limits,
+    ) -> layout::Node {
         layout::Node::new([100, 100].into())
     }
 
@@ -163,7 +169,7 @@ where
         &self,
         _state: &Tree,
         renderer: &mut Renderer,
-        _theme: &Renderer::Theme,
+        _theme: &Theme,
         _style: &renderer::Style,
         layout: Layout<'_>,
         _cursor: mouse::Cursor,
@@ -172,9 +178,12 @@ where
         renderer.fill_quad(
             Quad {
                 bounds: layout.bounds(),
-                border_radius: 10.0.into(),
-                border_width: 1.0,
-                border_color: Color::from_rgb(0.6, 0.8, 1.0),
+                border: Border {
+                    color: Color::from_rgb(0.6, 0.8, 1.0),
+                    width: 1.0,
+                    radius: 10.0.into(),
+                },
+                shadow: Shadow::default(),
             },
             if self.highlight {
                 Color::from_rgb(0.6, 0.8, 1.0)
@@ -185,7 +194,7 @@ where
     }
 }
 
-impl<'a, Message, Renderer> From<MyWidget> for Element<'a, Message, Renderer>
+impl<'a, Message, Renderer> From<MyWidget> for Element<'a, Message, Theme, Renderer>
 where
     Renderer: iced::advanced::Renderer,
 {

--- a/tutorial/width_and_height.md
+++ b/tutorial/width_and_height.md
@@ -1,13 +1,13 @@
 # Width And Height
 
 Most widgets have the `width` and `height` methods to control their sizes.
-The methods accept a parameter [Length](https://docs.rs/iced/latest/iced/enum.Length.html).
-There are four types of [Length](https://docs.rs/iced/latest/iced/enum.Length.html):
+The methods accept a parameter [Length](https://docs.rs/iced/0.12.1/iced/latest/iced/enum.Length.html).
+There are four types of [Length](https://docs.rs/iced/0.12.1/iced/latest/iced/enum.Length.html):
 
-* [Shrink](https://docs.rs/iced/latest/iced/enum.Length.html#variant.Shrink): occupy the least space.
-* [Fill](https://docs.rs/iced/latest/iced/enum.Length.html#variant.Fill): occupy all the rest of space.
-* [FillPortion](https://docs.rs/iced/latest/iced/enum.Length.html#variant.FillPortion): occupy the space relative to other widgets with [FillPortion](https://docs.rs/iced/latest/iced/enum.Length.html#variant.FillPortion).
-* [Fixed](https://docs.rs/iced/latest/iced/enum.Length.html#variant.Fixed): occupy a fixed space.
+* [Shrink](https://docs.rs/iced/0.12.1/iced/latest/iced/enum.Length.html#variant.Shrink): occupy the least space.
+* [Fill](https://docs.rs/iced/0.12.1/iced/enum.Length.html#variant.Fill): occupy all the rest of space.
+* [FillPortion](https://docs.rs/iced/0.12.1/iced/enum.Length.html#variant.FillPortion): occupy the space relative to other widgets with [FillPortion](https://docs.rs/iced/0.12.1/iced/enum.Length.html#variant.FillPortion).
+* [Fixed](https://docs.rs/iced/0.12.1/iced/enum.Length.html#variant.Fixed): occupy a fixed space.
 
 ```rust
 use iced::{


### PR DESCRIPTION
Hi,

I'm new to iced. After I've found your tutorial (thank you, by the way)  I've decided to dig deaper into Iced by updating the tutorial for version 0.12.1. Learning by doing, so to speak =)

I have managed to update everything except text_in_widgets exercise to the newer version. In that exercise the changed text::draw(...) broke me.

I hope this pull request will be usefull.

P.S. It my first pull request ever.