### PR TITLE
Update changing_the_window_dynamically.md

### DIFF
--- a/tutorial/batch_commands.md
+++ b/tutorial/batch_commands.md
@@ -58,7 +58,7 @@ impl Application for MyApp {
         Command::none()
     }
 
-    fn view(&self) -> iced::Element<'_, Self::Message, iced::Renderer<Self::Theme>> {
+    fn view(&self) -> iced::Element<'_, Self::Message, Self::Theme, iced::Renderer> {
         column![
             text_input("", &self.some_text)
                 .id(text_input::Id::new(MY_TEXT_ID))

--- a/tutorial/changing_the_window_dynamically.md
+++ b/tutorial/changing_the_window_dynamically.md
@@ -5,7 +5,8 @@ For example, to [resize](https://docs.rs/iced/0.12.1/iced/window/fn.resize.html)
 These functions return [Command](https://docs.rs/iced/0.12.1/iced/struct.Command.html), which can be used as the return value in [update](https://docs.rs/iced/0.12.1/iced/application/trait.Application.html#tymethod.update) method.
 Developers might be interested in other [Commands](https://docs.rs/iced/0.12.1/iced/struct.Command.html) in [window](https://docs.rs/iced/0.12.1/iced/window/index.html) module.
 
-Note: If you find [resize](https://docs.rs/iced/0.12.1/iced/window/fn.resize.html) needs an [Id](https://docs.rs/iced/0.12.1/iced/window/struct.Id.html), you can get it by [fetch_id](https://docs.rs/iced/0.12.1/iced/window/fn.fetch_id.html).
+Internally Iced reserves `window::Id::MAIN` for the first window spawned.
+
 
 ```rust
 use iced::{
@@ -55,10 +56,10 @@ impl Application for MyApp {
             MyAppMessage::UpdateWidth(w) => self.width = w,
             MyAppMessage::UpdateHeight(h) => self.height = h,
             MyAppMessage::ResizeWindow => {
-                return window::resize(Size::new(
-                    self.width.parse().unwrap(),
-                    self.height.parse().unwrap(),
-                ))
+                return window::resize(
+                    iced::window::Id::MAIN,
+                    Size::new(self.width.parse().unwrap(), self.height.parse().unwrap()),
+                )
             }
         }
         Command::none()

--- a/tutorial/closing_the_window_on_demand.md
+++ b/tutorial/closing_the_window_on_demand.md
@@ -45,7 +45,7 @@ impl Application for MyApp {
         }
     }
 
-    fn view(&self) -> iced::Element<'_, Self::Message, iced::Renderer<Self::Theme>> {
+    fn view(&self) -> iced::Element<'_, Self::Message, Self::Theme, iced::Renderer> {
         row![button("Close window").on_press(MyAppMessage::CloseWindow),].into()
     }
 }

--- a/tutorial/executing_custom_commands.md
+++ b/tutorial/executing_custom_commands.md
@@ -76,7 +76,7 @@ impl Application for MyApp {
         Command::none()
     }
 
-    fn view(&self) -> iced::Element<'_, Self::Message, iced::Renderer<Self::Theme>> {
+    fn view(&self) -> iced::Element<'_, Self::Message, Self::Theme,iced::Renderer> {
         column![
             button("Execute").on_press(MyAppMessage::Execute),
             text(self.state.as_str()),

--- a/tutorial/producing_messages_by_keyboard_events.md
+++ b/tutorial/producing_messages_by_keyboard_events.md
@@ -7,8 +7,7 @@ Instead of capturing [Event::Mouse](https://docs.rs/iced/0.12.1/iced/event/enum.
 use iced::{
     event::{self, Status},
     executor,
-    keyboard::{Event::KeyPressed, Key},
-    subscription,
+    keyboard::{key::Named, Event::KeyPressed, Key},
     widget::text,
     Application, Event, Settings,
 };
@@ -57,7 +56,7 @@ impl Application for MyApp {
     }
 
     fn subscription(&self) -> iced::Subscription<Self::Message> {
-        subscription::events_with(|event, status| match (event, status) {
+        event::listen_with(|event, status| match (event, status) {
             (
                 Event::Keyboard(KeyPressed {
                     key: Key::Named(Named::Enter),

--- a/tutorial/producing_messages_by_mouse_events.md
+++ b/tutorial/producing_messages_by_mouse_events.md
@@ -60,7 +60,7 @@ impl Application for MyApp {
         iced::Command::none()
     }
 
-    fn view(&self) -> iced::Element<'_, Self::Message, iced::Renderer<Self::Theme>> {
+    fn view(&self) -> iced::Element<'_, Self::Message, Self::Theme, iced::Renderer> {
         text(format!("{:?}", self.mouse_point)).into()
     }
 


### PR DESCRIPTION
According to [iced documentation](https://docs.rs/iced/0.12.1/iced/window/fn.fetch_id.html), fetch_id should be  `Fetches an identifier unique to the window, provided by the underlying windowing system. This is not to be confused with Id.`
So it should be corrected to [`window::Id::MAIN`](https://docs.rs/iced/0.12.1/iced/window/struct.Id.html)