### PR TITLE
Update the signature of the view method

### DIFF
--- a/tutorial/adding_widgets.md
+++ b/tutorial/adding_widgets.md
@@ -27,7 +27,7 @@ impl Sandbox for MyApp {
 
     fn update(&mut self, _message: Self::Message) {}
 
-    fn view(&self) -> iced::Element<'_, Self::Message> {
+    fn view(&self) -> iced::Element<Self::Message> {
         column![
             text("Yes or no?"),
             row![

--- a/tutorial/batch_commands.md
+++ b/tutorial/batch_commands.md
@@ -58,7 +58,7 @@ impl Application for MyApp {
         Command::none()
     }
 
-    fn view(&self) -> iced::Element<'_, Self::Message, Self::Theme, iced::Renderer> {
+    fn view(&self) -> iced::Element<Self::Message> {
         column![
             text_input("", &self.some_text)
                 .id(text_input::Id::new(MY_TEXT_ID))

--- a/tutorial/batch_subscriptions.md
+++ b/tutorial/batch_subscriptions.md
@@ -59,7 +59,7 @@ impl Application for MyApp {
         Command::none()
     }
 
-    fn view(&self) -> iced::Element<'_, Self::Message> {
+    fn view(&self) -> iced::Element<Self::Message> {
         text(self.seconds).into()
     }
 

--- a/tutorial/button.md
+++ b/tutorial/button.md
@@ -35,7 +35,7 @@ impl Sandbox for MyApp {
 
     fn update(&mut self, _message: Self::Message) {}
 
-    fn view(&self) -> iced::Element<'_, Self::Message> {
+    fn view(&self) -> iced::Element<Self::Message> {
         column![
             Button::new("Disabled button"),
             button("Construct from function"),

--- a/tutorial/changing_displaying_content.md
+++ b/tutorial/changing_displaying_content.md
@@ -43,7 +43,7 @@ impl Sandbox for MyApp {
         }
     }
 
-    fn view(&self) -> iced::Element<'_, Self::Message> {
+    fn view(&self) -> iced::Element<Self::Message> {
         column![
             text(self.counter),
             button("Increase").on_press(MyAppMessage::ButtonPressed),

--- a/tutorial/changing_styles.md
+++ b/tutorial/changing_styles.md
@@ -10,7 +10,7 @@ Since [theme::Text](https://docs.rs/iced/0.12.1/iced/theme/enum.Text.html) imple
 use iced::{
     theme,
     widget::{button, column, row, text},
-    Sandbox, Settings, Color,
+    Color, Sandbox, Settings,
 };
 
 fn main() -> iced::Result {
@@ -37,7 +37,7 @@ impl Sandbox for MyApp {
 
     fn update(&mut self, _message: Self::Message) {}
 
-    fn view(&self) -> iced::Element<'_, Self::Message> {
+    fn view(&self) -> iced::Element<Self::Message> {
         column![
             text("Ready?").style(Color::from_rgb(1., 0.6, 0.2)),
             row![

--- a/tutorial/changing_the_window_dynamically.md
+++ b/tutorial/changing_the_window_dynamically.md
@@ -5,8 +5,8 @@ For example, to [resize](https://docs.rs/iced/0.12.1/iced/window/fn.resize.html)
 These functions return [Command](https://docs.rs/iced/0.12.1/iced/struct.Command.html), which can be used as the return value in [update](https://docs.rs/iced/0.12.1/iced/application/trait.Application.html#tymethod.update) method.
 Developers might be interested in other [Commands](https://docs.rs/iced/0.12.1/iced/struct.Command.html) in [window](https://docs.rs/iced/0.12.1/iced/window/index.html) module.
 
-Internally Iced reserves `window::Id::MAIN` for the first window spawned.
-
+The [resize](https://docs.rs/iced/0.12.1/iced/window/fn.resize.html) function needs an ID of the window we are going to resize.
+Internally, Iced reserves [window::Id::MAIN](https://docs.rs/iced/0.12.1/iced/window/struct.Id.html#associatedconstant.MAIN) for the first window spawned.
 
 ```rust
 use iced::{
@@ -65,7 +65,7 @@ impl Application for MyApp {
         Command::none()
     }
 
-    fn view(&self) -> iced::Element<'_, Self::Message> {
+    fn view(&self) -> iced::Element<Self::Message> {
         row![
             text_input("Width", &self.width).on_input(MyAppMessage::UpdateWidth),
             text_input("Height", &self.height).on_input(MyAppMessage::UpdateHeight),

--- a/tutorial/changing_themes.md
+++ b/tutorial/changing_themes.md
@@ -24,7 +24,7 @@ impl Sandbox for MyApp {
 
     fn update(&mut self, _message: Self::Message) {}
 
-    fn view(&self) -> iced::Element<'_, Self::Message> {
+    fn view(&self) -> iced::Element<Self::Message> {
         "Hello".into()
     }
 

--- a/tutorial/checkbox.md
+++ b/tutorial/checkbox.md
@@ -56,7 +56,7 @@ impl Sandbox for MyApp {
         }
     }
 
-    fn view(&self) -> iced::Element<'_, Self::Message> {
+    fn view(&self) -> iced::Element<Self::Message> {
         column![
             Checkbox::new("Construct from struct", false),
             checkbox("Construct from function", false),

--- a/tutorial/closing_the_window_on_demand.md
+++ b/tutorial/closing_the_window_on_demand.md
@@ -2,9 +2,10 @@
 
 This tutorial follows the [previous tutorial](./changing_the_window_dynamically.md).
 We use the [close](https://docs.rs/iced/0.12.1/iced/window/fn.close.html) function in [window](https://docs.rs/iced/0.12.1/iced/window/index.html) module to close the window.
-This is also done by returning the [Command](https://docs.rs/iced/0.12.1/iced/struct.Command.html) obtained by [close](https://docs.rs/iced/0.12.1/iced/window/fn.close.html) function.
+This is also done by returning the [Command](https://docs.rs/iced/0.12.1/iced/struct.Command.html) obtained by the [close](https://docs.rs/iced/0.12.1/iced/window/fn.close.html) function.
 
-Note: If you find the function needs an [Id](https://docs.rs/iced/0.12.1/iced/window/struct.Id.html), you can get it by [fetch_id](https://docs.rs/iced/0.12.1/iced/window/fn.fetch_id.html).
+Similar to the [resize](https://docs.rs/iced/0.12.1/iced/window/fn.resize.html) function, the [close](https://docs.rs/iced/0.12.1/iced/window/fn.close.html) function also needs an ID of the window.
+We pass [window::Id::MAIN](https://docs.rs/iced/0.12.1/iced/window/struct.Id.html#associatedconstant.MAIN) for the ID.
 
 ```rust
 use iced::{
@@ -40,12 +41,11 @@ impl Application for MyApp {
 
     fn update(&mut self, message: Self::Message) -> iced::Command<Self::Message> {
         match message {
-            MyAppMessage::CloseWindow => window::close(),
-			// MyAppMessage::CloseWindow => window::close(window::Id::MAIN),
+            MyAppMessage::CloseWindow => window::close(window::Id::MAIN),
         }
     }
 
-    fn view(&self) -> iced::Element<'_, Self::Message, Self::Theme, iced::Renderer> {
+    fn view(&self) -> iced::Element<Self::Message> {
         row![button("Close window").on_press(MyAppMessage::CloseWindow),].into()
     }
 }

--- a/tutorial/column.md
+++ b/tutorial/column.md
@@ -30,7 +30,7 @@ impl Sandbox for MyApp {
 
     fn update(&mut self, _message: Self::Message) {}
 
-    fn view(&self) -> iced::Element<'_, Self::Message> {
+    fn view(&self) -> iced::Element<Self::Message> {
         column![
             Column::with_children(vec![
                 "Construct from the with_children function".into(),

--- a/tutorial/combobox.md
+++ b/tutorial/combobox.md
@@ -107,7 +107,7 @@ impl Sandbox for MyApp {
         }
     }
 
-    fn view(&self) -> iced::Element<'_, Self::Message> {
+    fn view(&self) -> iced::Element<Self::Message> {
         column![
             ComboBox::new(&self.state1, "Construct from struct", None, |_| {
                 MyAppMessage::DoNothing

--- a/tutorial/container.md
+++ b/tutorial/container.md
@@ -29,7 +29,7 @@ impl Sandbox for MyApp {
 
     fn update(&mut self, _message: Self::Message) {}
 
-    fn view(&self) -> iced::Element<'_, Self::Message> {
+    fn view(&self) -> iced::Element<Self::Message> {
         column![
             Container::new("Construct from struct"),
             container("Construct from function"),

--- a/tutorial/controlling_widgets_by_commands.md
+++ b/tutorial/controlling_widgets_by_commands.md
@@ -57,7 +57,7 @@ impl Application for MyApp {
         Command::none()
     }
 
-    fn view(&self) -> iced::Element<'_, Self::Message> {
+    fn view(&self) -> iced::Element<Self::Message> {
         column![
             button("Edit text").on_press(MyAppMessage::EditText),
             text_input("", &self.some_text)

--- a/tutorial/custom_background.md
+++ b/tutorial/custom_background.md
@@ -55,26 +55,25 @@ fn draw(
     _viewport: &Rectangle,
 ) {
     renderer.fill_quad(
-		Quad {
-			bounds: layout.bounds(),
-			border: Border {
-				color: Color::from_rgb(1.0, 0.66, 0.6),
-				width: 1.0,
-				radius: 10.0.into(),
-			},
-			shadow: Shadow::default(),
-		},
-		Color::BLACK,
+        Quad {
+            bounds: layout.bounds(),
+            border: Border {
+                color: Color::from_rgb(1.0, 0.66, 0.6),
+                width: 1.0,
+                radius: 10.0.into(),
+            },
+            shadow: Shadow::default(),
+        },
+        Color::BLACK,
     );
-	
-	iced::widget::image::draw(
-		renderer,
-		layout,
-		&self.handle,
-		iced::ContentFit::Contain,
-		iced::widget::image::FilterMethod::Linear,
-	);
 
+    iced::widget::image::draw(
+        renderer,
+        layout,
+        &self.handle,
+        iced::ContentFit::Contain,
+        iced::widget::image::FilterMethod::Linear,
+    );
 }
 ```
 
@@ -119,7 +118,7 @@ impl Sandbox for MyApp {
 
     fn update(&mut self, _message: Self::Message) {}
 
-    fn view(&self) -> iced::Element<'_, Self::Message> {
+    fn view(&self) -> iced::Element<Self::Message> {
         container(MyWidgetWithImage::new())
             .width(Length::Fill)
             .height(Length::Fill)

--- a/tutorial/custom_styles.md
+++ b/tutorial/custom_styles.md
@@ -40,7 +40,7 @@ impl Sandbox for MyApp {
 
     fn update(&mut self, _message: Self::Message) {}
 
-    fn view(&self) -> iced::Element<'_, Self::Message> {
+    fn view(&self) -> iced::Element<Self::Message> {
         column![
             radio("Choice A", "A", Some("A"), |s| MyAppMessage::Choose(
                 s.to_string()

--- a/tutorial/drawing_shapes.md
+++ b/tutorial/drawing_shapes.md
@@ -70,7 +70,7 @@ impl Sandbox for MyApp {
 
     fn update(&mut self, _message: Self::Message) {}
 
-    fn view(&self) -> iced::Element<'_, Self::Message> {
+    fn view(&self) -> iced::Element<Self::Message> {
         column![
             "A Canvas",
             Canvas::new(MyProgram)
@@ -96,7 +96,7 @@ impl<Message> Program<Message> for MyProgram {
         _cursor: mouse::Cursor,
     ) -> Vec<Geometry> {
         let mut frame = Frame::new(renderer, bounds.size());
-        
+
         frame.fill_rectangle(Point::ORIGIN, bounds.size(), Color::from_rgb(0.0, 0.2, 0.4));
 
         frame.fill(

--- a/tutorial/drawing_widgets.md
+++ b/tutorial/drawing_widgets.md
@@ -18,17 +18,17 @@ impl<Message, Renderer> Widget<Message, Theme, Renderer> for MyWidget
 where
     Renderer: iced::advanced::Renderer,
 {
-	fn size(&self) -> Size<Length> {
-		// ...
-	}
-	
+    fn size(&self) -> Size<Length> {
+        // ...
+    }
+
     fn layout(
         &self,
         _tree: &mut Tree,
         _renderer: &Renderer,
         _limits: &layout::Limits,
     ) -> layout::Node {
-		// ...
+        // ...
     }
 
     fn draw(
@@ -51,10 +51,10 @@ Currently, we set the width and height to [Length::Shrink](https://docs.rs/iced/
 
 ```rust
 fn size(&self) -> Size<Length> {
-	Size {
-		width: Length::Shrink,
-		height: Length::Shrink,
-	}
+    Size {
+        width: Length::Shrink,
+        height: Length::Shrink,
+    }
 }
 ```
 
@@ -86,15 +86,15 @@ fn draw(
     _viewport: &Rectangle,
 ) {
     renderer.fill_quad(
-		Quad {
-			bounds: layout.bounds(),
-			border: Border {
-				color: Color::from_rgb(0.6, 0.8, 1.0),
-				width: 1.0,
-				radius: 10.0.into(),
-			},
-			shadow: Shadow::default(),
-		},
+        Quad {
+            bounds: layout.bounds(),
+            border: Border {
+                color: Color::from_rgb(0.6, 0.8, 1.0),
+                width: 1.0,
+                radius: 10.0.into(),
+            },
+            shadow: Shadow::default(),
+        },
         Color::from_rgb(0.0, 0.2, 0.4),
     );
 }
@@ -118,7 +118,7 @@ where
 Finally, the widget can be added to our app by the following code.
 
 ```rust
-fn view(&self) -> iced::Element<'_, Self::Message> {
+fn view(&self) -> iced::Element<Self::Message> {
     container(MyWidget)
         .width(Length::Fill)
         .height(Length::Fill)
@@ -132,7 +132,7 @@ Note that it is not necessary to put `MyWidget` in a [Container](https://docs.rs
 We can add the widget directly into our app.
 
 ```rust
-fn view(&self) -> iced::Element<'_, Self::Message> {
+fn view(&self) -> iced::Element<Self::Message> {
     MyWidget.into()
 }
 ```
@@ -170,7 +170,7 @@ impl Sandbox for MyApp {
 
     fn update(&mut self, _message: Self::Message) {}
 
-    fn view(&self) -> iced::Element<'_, Self::Message> {
+    fn view(&self) -> iced::Element<Self::Message> {
         container(MyWidget)
             .width(Length::Fill)
             .height(Length::Fill)

--- a/tutorial/drawing_with_caches.md
+++ b/tutorial/drawing_with_caches.md
@@ -80,7 +80,7 @@ impl Sandbox for MyApp {
 
     fn update(&mut self, _message: Self::Message) {}
 
-    fn view(&self) -> iced::Element<'_, Self::Message> {
+    fn view(&self) -> iced::Element<Self::Message> {
         column![
             "A Canvas",
             Canvas::new(self).width(Length::Fill).height(Length::Fill)

--- a/tutorial/executing_custom_commands.md
+++ b/tutorial/executing_custom_commands.md
@@ -4,21 +4,21 @@
 To do this, we need to enable one of the following features: [tokio](https://docs.rs/crate/iced/0.12.1/features#tokio), [async-std](https://docs.rs/crate/iced/0.12.1/features#async-std), or [smol](https://docs.rs/crate/iced/0.12.1/features#smol).
 The corresponding asynchronous runtime ([tokio](https://crates.io/crates/tokio), [async-std](https://crates.io/crates/async-std), or [smol](https://crates.io/crates/smol)) must also be added.
 
-Here, we use [async-std](https://crates.io/crates/async-std) as an example.
-We enable [async-std](https://docs.rs/crate/iced/latest/features#async-std) feature and add [async-std](https://crates.io/crates/async-std) crate.
-The `Cargo.toml` should look like this:
+Here, we use [tokio](https://crates.io/crates/tokio) as an example.
+We enable [tokio](https://docs.rs/crate/iced/0.12.1/features#tokio) feature and add [tokio](https://crates.io/crates/tokio) crate.
+The dependencies of `Cargo.toml` should look like this:
 
 ```toml
 [dependencies]
-async-std = "1.12.0"
-iced = { version = "0.12.1", features = ["async-std"] }
+iced = { version = "0.12.1", features = ["tokio"] }
+tokio = { version = "1.37.0", features = ["time"] }
 ```
 
 We use [Command::perform](https://docs.rs/iced/0.12.1/iced/struct.Command.html#method.perform) to execute an asynchronous function.
 The first parameter of [Command::perform](https://docs.rs/iced/0.12.1/iced/struct.Command.html#method.perform) is an asynchronous function, and the second parameter is a function that returns `MyAppMessage`.
 The `MyAppMessage` will be produced once the asynchronous function is done.
 
-In the following code, we use a simple asynchronous function [async_std::task::sleep](https://docs.rs/async-std/1.12.0/async_std/task/fn.sleep.html).
+In the following code, we use a simple asynchronous function [tokio::time::sleep](https://docs.rs/tokio/latest/tokio/time/fn.sleep.html).
 When the asynchronous function finished, we will receive `MyAppMessage::Done`.
 
 ```rust
@@ -67,7 +67,7 @@ impl Application for MyApp {
         match message {
             MyAppMessage::Execute => {
                 self.state = "Executing".into();
-                return Command::perform(async_std::task::sleep(Duration::from_secs(1)), |_| {
+                return Command::perform(tokio::time::sleep(Duration::from_secs(1)), |_| {
                     MyAppMessage::Done
                 });
             }
@@ -76,7 +76,7 @@ impl Application for MyApp {
         Command::none()
     }
 
-    fn view(&self) -> iced::Element<'_, Self::Message, Self::Theme,iced::Renderer> {
+    fn view(&self) -> iced::Element<Self::Message> {
         column![
             button("Execute").on_press(MyAppMessage::Execute),
             text(self.state.as_str()),

--- a/tutorial/explanation_of_sandbox_trait.md
+++ b/tutorial/explanation_of_sandbox_trait.md
@@ -35,7 +35,7 @@ impl Sandbox for MyApp {
         }
     }
 
-    fn view(&self) -> iced::Element<'_, Self::Message> {
+    fn view(&self) -> iced::Element<Self::Message> {
         // View logic
     }
 }

--- a/tutorial/first_app.md
+++ b/tutorial/first_app.md
@@ -25,7 +25,7 @@ impl Sandbox for MyApp {
 
     fn update(&mut self, _message: Self::Message) {}
 
-    fn view(&self) -> iced::Element<'_, Self::Message> {
+    fn view(&self) -> iced::Element<Self::Message> {
         "Hello World!".into()
     }
 }

--- a/tutorial/from_sandbox_to_application.md
+++ b/tutorial/from_sandbox_to_application.md
@@ -35,7 +35,7 @@ impl Application for MyApp {
         Command::none()
     }
 
-    fn view(&self) -> iced::Element<'_, Self::Message> {
+    fn view(&self) -> iced::Element<Self::Message> {
         "Hello World!".into()
     }
 }

--- a/tutorial/image.md
+++ b/tutorial/image.md
@@ -39,7 +39,7 @@ impl Sandbox for MyApp {
 
     fn update(&mut self, _message: Self::Message) {}
 
-    fn view(&self) -> iced::Element<'_, Self::Message> {
+    fn view(&self) -> iced::Element<Self::Message> {
         column![
             text("Construct from struct"),
             Image::new("ferris.png"),

--- a/tutorial/initializing_a_different_window.md
+++ b/tutorial/initializing_a_different_window.md
@@ -11,7 +11,7 @@ fn main() -> iced::Result {
         window: window::Settings {
             size: Size {
                 width: 70.,
-                height: 20.,
+                height: 30.,
             },
             position: window::Position::Specific(Point { x: 50., y: 60. }),
             ..window::Settings::default()
@@ -35,7 +35,7 @@ impl Sandbox for MyApp {
 
     fn update(&mut self, _message: Self::Message) {}
 
-    fn view(&self) -> iced::Element<'_, Self::Message> {
+    fn view(&self) -> iced::Element<Self::Message> {
         "Hello".into()
     }
 }

--- a/tutorial/loading_images_asynchronously.md
+++ b/tutorial/loading_images_asynchronously.md
@@ -38,7 +38,7 @@ In the *loading* state, the app shows the text `Loading...`.
 And in the *loaded* state, the app shows the image.
 
 ```rust
-fn view(&self) -> iced::Element<'_, Self::Message, iced::Renderer<Self::Theme>> {
+fn view(&self) -> iced::Element<Self::Message> {
     column![
         button("Load").on_press(MyMessage::Load),
         if self.show_container {
@@ -155,7 +155,7 @@ impl Application for MyApp {
         Command::none()
     }
 
-    fn view(&self) -> iced::Element<'_, Self::Message> {
+    fn view(&self) -> iced::Element<Self::Message> {
         column![
             button("Load").on_press(MyMessage::Load),
             if self.show_container {

--- a/tutorial/memoryless_pages.md
+++ b/tutorial/memoryless_pages.md
@@ -55,7 +55,7 @@ impl Sandbox for MyApp {
         }
     }
 
-    fn view(&self) -> iced::Element<'_, Self::Message> {
+    fn view(&self) -> iced::Element<Self::Message> {
         self.page.view()
     }
 }
@@ -91,7 +91,7 @@ impl Page for PageB {
         None
     }
 
-    fn view(&self) -> iced::Element<'_, MyAppMessage> {
+    fn view(&self) -> iced::Element<MyAppMessage> {
         column![
             text("Hello!"),
             button("Log out").on_press(MyAppMessage::PageB(Mb::ButtonPressed)),
@@ -143,7 +143,7 @@ impl Page for PageA {
         None
     }
 
-    fn view(&self) -> iced::Element<'_, MyAppMessage> {
+    fn view(&self) -> iced::Element<MyAppMessage> {
         column![
             text_input("Password", &self.password)
                 .secure(true)

--- a/tutorial/more_than_one_page.md
+++ b/tutorial/more_than_one_page.md
@@ -46,7 +46,7 @@ impl Sandbox for MyApp {
         }
     }
 
-    fn view(&self) -> iced::Element<'_, Self::Message> {
+    fn view(&self) -> iced::Element<Self::Message> {
         match self.page {
             Page::A => column![
                 text("Page A"),

--- a/tutorial/mouse_pointer_over_widgets.md
+++ b/tutorial/mouse_pointer_over_widgets.md
@@ -55,7 +55,7 @@ impl Sandbox for MyApp {
 
     fn update(&mut self, _message: Self::Message) {}
 
-    fn view(&self) -> iced::Element<'_, Self::Message> {
+    fn view(&self) -> iced::Element<Self::Message> {
         container(MyWidget)
             .width(Length::Fill)
             .height(Length::Fill)

--- a/tutorial/navigation_history.md
+++ b/tutorial/navigation_history.md
@@ -31,7 +31,7 @@ enum Navigation {
 
 trait Page {
     fn update(&mut self, message: MyAppMessage) -> Navigation;
-    fn view(&self) -> iced::Element<'_, MyAppMessage>;
+    fn view(&self) -> iced::Element<MyAppMessage>;
 }
 
 struct MyApp {
@@ -64,7 +64,7 @@ impl Sandbox for MyApp {
         }
     }
 
-    fn view(&self) -> iced::Element<'_, Self::Message> {
+    fn view(&self) -> iced::Element<Self::Message> {
         self.pages.last().unwrap().view()
     }
 }
@@ -99,7 +99,7 @@ impl Page for PageA {
         Navigation::None
     }
 
-    fn view(&self) -> iced::Element<'_, MyAppMessage> {
+    fn view(&self) -> iced::Element<MyAppMessage> {
         column![
             text("Start"),
             button("Next").on_press(MyAppMessage::PageA(Ma::ButtonPressed)),
@@ -144,7 +144,7 @@ impl Page for PageB {
         Navigation::None
     }
 
-    fn view(&self) -> iced::Element<'_, MyAppMessage> {
+    fn view(&self) -> iced::Element<MyAppMessage> {
         column![
             text(self.id),
             row![

--- a/tutorial/on_pressed_released_of_some_widgets.md
+++ b/tutorial/on_pressed_released_of_some_widgets.md
@@ -41,7 +41,7 @@ impl Sandbox for MyApp {
         }
     }
 
-    fn view(&self) -> iced::Element<'_, Self::Message> {
+    fn view(&self) -> iced::Element<Self::Message> {
         mouse_area(self.state.as_str())
             .on_press(MyAppMessage::Pressed)
             .on_release(MyAppMessage::Released)

--- a/tutorial/passing_parameters_across_pages.md
+++ b/tutorial/passing_parameters_across_pages.md
@@ -21,7 +21,7 @@ enum MyAppMessage {
 
 trait Page {
     fn update(&mut self, message: MyAppMessage) -> Option<Box<dyn Page>>;
-    fn view(&self) -> iced::Element<'_, MyAppMessage>;
+    fn view(&self) -> iced::Element<MyAppMessage>;
 }
 
 struct MyApp {
@@ -48,7 +48,7 @@ impl Sandbox for MyApp {
         }
     }
 
-    fn view(&self) -> iced::Element<'_, Self::Message> {
+    fn view(&self) -> iced::Element<Self::Message> {
         self.page.view()
     }
 }
@@ -90,7 +90,7 @@ impl Page for PageA {
         None
     }
 
-    fn view(&self) -> iced::Element<'_, MyAppMessage> {
+    fn view(&self) -> iced::Element<MyAppMessage> {
         column![
             text_input("Name", &self.name).on_input(|s| MyAppMessage::PageA(Ma::TextChanged(s))),
             button("Log in").on_press(MyAppMessage::PageA(Ma::ButtonPressed)),
@@ -131,7 +131,7 @@ impl Page for PageB {
         None
     }
 
-    fn view(&self) -> iced::Element<'_, MyAppMessage> {
+    fn view(&self) -> iced::Element<MyAppMessage> {
         column![
             text(format!("Hello {}!", self.name)),
             button("Log out").on_press(MyAppMessage::PageB(Mb::ButtonPressed)),

--- a/tutorial/picklist.md
+++ b/tutorial/picklist.md
@@ -57,7 +57,7 @@ impl Sandbox for MyApp {
         }
     }
 
-    fn view(&self) -> iced::Element<'_, Self::Message> {
+    fn view(&self) -> iced::Element<Self::Message> {
         column![
             PickList::new(
                 vec!["Construct from struct"],

--- a/tutorial/producing_messages_by_keyboard_events.md
+++ b/tutorial/producing_messages_by_keyboard_events.md
@@ -51,7 +51,7 @@ impl Application for MyApp {
         iced::Command::none()
     }
 
-    fn view(&self) -> iced::Element<'_, Self::Message> {
+    fn view(&self) -> iced::Element<Self::Message> {
         text(self.pressed_key.as_str()).into()
     }
 

--- a/tutorial/producing_messages_by_mouse_events.md
+++ b/tutorial/producing_messages_by_mouse_events.md
@@ -60,7 +60,7 @@ impl Application for MyApp {
         iced::Command::none()
     }
 
-    fn view(&self) -> iced::Element<'_, Self::Message, Self::Theme, iced::Renderer> {
+    fn view(&self) -> iced::Element<Self::Message> {
         text(format!("{:?}", self.mouse_point)).into()
     }
 

--- a/tutorial/producing_messages_by_timers.md
+++ b/tutorial/producing_messages_by_timers.md
@@ -1,12 +1,12 @@
 # Producing Messages By Timers
 
 To use build-in timers, we need to enable one of the following features: [tokio](https://docs.rs/crate/iced/0.12.1/features#tokio), [async-std](https://docs.rs/crate/iced/0.12.1/features#async-std), or [smol](https://docs.rs/crate/iced/0.12.1/features#smol).
-In this tutorial, we use [async-std](https://docs.rs/crate/iced/0.12.1/features#async-std) feature.
-The `Cargo.toml` should look like this:
+In this tutorial, we use [tokio](https://docs.rs/crate/iced/0.12.1/features#tokio) feature.
+The dependencies of `Cargo.toml` should look like this:
 
 ```toml
 [dependencies]
-iced = { version = "0.10.0", features = ["async-std"] }
+iced = { version = "0.12.1", features = ["tokio"] }
 ```
 
 We use [time::every](https://docs.rs/iced/0.12.1/iced/time/fn.every.html) function to obtain [Subscription](https://docs.rs/iced/0.12.1/iced/struct.Subscription.html)\<[Instant](https://docs.rs/iced/0.12.1/iced/time/struct.Instant.html)> struct.
@@ -56,7 +56,7 @@ impl Application for MyApp {
         Command::none()
     }
 
-    fn view(&self) -> iced::Element<'_, Self::Message> {
+    fn view(&self) -> iced::Element<Self::Message> {
         text(self.seconds).into()
     }
 

--- a/tutorial/producing_widget_messages.md
+++ b/tutorial/producing_widget_messages.md
@@ -89,7 +89,7 @@ use iced::{
         Clipboard, Layout, Shell, Widget,
     },
     widget::{column, container, text},
-    Alignment, Border, Color, Element, Event, Length, Rectangle, Sandbox, Settings, Shadow, Size, Theme,
+    Border, Color, Element, Event, Length, Rectangle, Sandbox, Settings, Shadow, Size, Theme,
 };
 
 fn main() -> iced::Result {
@@ -122,7 +122,7 @@ impl Sandbox for MyApp {
         }
     }
 
-    fn view(&self) -> iced::Element<'_, Self::Message> {
+    fn view(&self) -> iced::Element<Self::Message> {
         container(
             column![MyWidget::new(MyMessage::MyWidgetPressed), text(self.count)]
                 .spacing(20)

--- a/tutorial/progressbar.md
+++ b/tutorial/progressbar.md
@@ -28,7 +28,7 @@ impl Sandbox for MyApp {
 
     fn update(&mut self, _message: Self::Message) {}
 
-    fn view(&self) -> iced::Element<'_, Self::Message> {
+    fn view(&self) -> iced::Element<Self::Message> {
         column![
             text("Construct from struct"),
             ProgressBar::new(0.0..=100.0, 50.),

--- a/tutorial/radio.md
+++ b/tutorial/radio.md
@@ -51,7 +51,7 @@ impl Sandbox for MyApp {
         }
     }
 
-    fn view(&self) -> iced::Element<'_, Self::Message> {
+    fn view(&self) -> iced::Element<Self::Message> {
         column![
             Radio::new("Construct from struct", 0, None, |_| {
                 MyAppMessage::DoNothing

--- a/tutorial/row.md
+++ b/tutorial/row.md
@@ -30,7 +30,7 @@ impl Sandbox for MyApp {
 
     fn update(&mut self, _message: Self::Message) {}
 
-    fn view(&self) -> iced::Element<'_, Self::Message> {
+    fn view(&self) -> iced::Element<Self::Message> {
         column![
             Row::with_children(vec![
                 "Construct from the with_children function.".into(),

--- a/tutorial/rule.md
+++ b/tutorial/rule.md
@@ -30,7 +30,7 @@ impl Sandbox for MyApp {
 
     fn update(&mut self, _message: Self::Message) {}
 
-    fn view(&self) -> iced::Element<'_, Self::Message> {
+    fn view(&self) -> iced::Element<Self::Message> {
         column![
             text("Construct from struct"),
             Rule::horizontal(0),

--- a/tutorial/scrollable.md
+++ b/tutorial/scrollable.md
@@ -47,21 +47,16 @@ impl Sandbox for MyApp {
         }
     }
 
-    fn view(&self) -> iced::Element<'_, Self::Message> {
-        let long_vertical_texts = column(
-            (0..10)
-                .map(|i| text(format!("{} vertical scrollable", i + 1)).into())
-        );
-        let long_horizontal_texts = row((0..10)
-            .map(|i| text(format!("{} horizontal scrollable  ", i + 1)).into())
-        );
+    fn view(&self) -> iced::Element<Self::Message> {
+        let long_vertical_texts =
+            column((0..10).map(|i| text(format!("{} vertical scrollable", i + 1)).into()));
+        let long_horizontal_texts =
+            row((0..10).map(|i| text(format!("{} horizontal scrollable  ", i + 1)).into()));
         let long_both_texts = column(
-            (0..10)
-                .map(|i| text(format!("{} vertical and horizontal scrollable", i + 1)).into())
+            (0..10).map(|i| text(format!("{} vertical and horizontal scrollable", i + 1)).into()),
         );
         let long_both_texts_2 = column(
-            (0..10)
-                .map(|i| text(format!("{} vertical and horizontal scrollable", i + 1)).into())
+            (0..10).map(|i| text(format!("{} vertical and horizontal scrollable", i + 1)).into()),
         );
 
         column![

--- a/tutorial/slider.md
+++ b/tutorial/slider.md
@@ -70,7 +70,7 @@ impl Sandbox for MyApp {
         }
     }
 
-    fn view(&self) -> iced::Element<'_, Self::Message> {
+    fn view(&self) -> iced::Element<Self::Message> {
         column![
             text("Construct from struct"),
             Slider::new(0..=100, 50, |_| MyAppMessage::DoNothing),

--- a/tutorial/space.md
+++ b/tutorial/space.md
@@ -29,26 +29,23 @@ impl Sandbox for MyApp {
 
     fn update(&mut self, _message: Self::Message) {}
 
-    fn view(&self) -> iced::Element<'_, Self::Message> {
+    fn view(&self) -> iced::Element<Self::Message> {
         column![
             row![
                 button("Horizontal space 1A"),
                 Space::with_width(50),
                 button("Horizontal space 1B"),
             ],
-
             row![
                 button("Horizontal space 2A"),
                 Space::with_width(Length::Fill),
                 button("Horizontal space 2B"),
             ],
-
             row![
                 button("Horizontal space 3A"),
                 horizontal_space(),
                 button("Horizontal space 3B"),
             ],
-
             button("Vertical space 1A"),
             Space::with_height(50),
             button("Vertical space 1B"),
@@ -56,7 +53,6 @@ impl Sandbox for MyApp {
             button("Vertical space 2A"),
             vertical_space(),
             button("Vertical space 2B"),
-            
             button("Diagonal space A"),
             row![Space::new(50, 50), button("Diagonal space B"),].align_items(Alignment::End)
         ]

--- a/tutorial/svg.md
+++ b/tutorial/svg.md
@@ -49,7 +49,7 @@ impl Sandbox for MyApp {
 
     fn update(&mut self, _message: Self::Message) {}
 
-    fn view(&self) -> iced::Element<'_, Self::Message> {
+    fn view(&self) -> iced::Element<Self::Message> {
         column![
             text("Construct from struct"),
             Svg::from_path("pic.svg"),

--- a/tutorial/taking_any_children.md
+++ b/tutorial/taking_any_children.md
@@ -25,21 +25,21 @@ So, we have to cast it as [Widget](https://docs.rs/iced/0.12.1/iced/advanced/wid
 
 ```rust
 fn layout(
-	&self,
-	tree: &mut Tree,
-	renderer: &Renderer,
-	limits: &layout::Limits,
+    &self,
+    tree: &mut Tree,
+    renderer: &Renderer,
+    limits: &layout::Limits,
 ) -> layout::Node {
-	let mut child_node =
-		self.inner_widget
-			.as_widget()
-			.layout(&mut tree.children[0], renderer, limits);
+    let mut child_node =
+        self.inner_widget
+            .as_widget()
+            .layout(&mut tree.children[0], renderer, limits);
 
-	let size_of_this_node = child_node.size().expand(Size::new(50., 50.));
+    let size_of_this_node = child_node.size().expand(Size::new(50., 50.));
 
-	child_node = child_node.align(Alignment::Center, Alignment::Center, size_of_this_node);
+    child_node = child_node.align(Alignment::Center, Alignment::Center, size_of_this_node);
 
-	layout::Node::with_children(size_of_this_node, vec![child_node])
+    layout::Node::with_children(size_of_this_node, vec![child_node])
 }
 ```
 
@@ -50,37 +50,37 @@ Then, in the [draw](https://docs.rs/iced/0.12.1/iced/advanced/widget/trait.Widge
 
 ```rust
 fn draw(
-	&self,
-	state: &Tree,
-	renderer: &mut Renderer,
-	theme: &Theme,
-	style: &renderer::Style,
-	layout: Layout<'_>,
-	cursor: mouse::Cursor,
-	viewport: &Rectangle,
+    &self,
+    state: &Tree,
+    renderer: &mut Renderer,
+    theme: &Theme,
+    style: &renderer::Style,
+    layout: Layout<'_>,
+    cursor: mouse::Cursor,
+    viewport: &Rectangle,
 ) {
-	renderer.fill_quad(
-		Quad {
-			bounds: layout.bounds(),
-			border: Border {
-				color: Color::from_rgb(0.6, 0.93, 1.0),
-				width: 1.0,
-				radius: 10.0.into(),
-			},
-			shadow: Shadow::default(),
-		},
-		Color::from_rgb(0.0, 0.33, 0.4),
-	);
-	
-	self.inner_widget.as_widget().draw(
-		&state.children[0],
-		renderer,
-		theme,
-		style,
-		layout.children().next().unwrap(),
-		cursor,
-		viewport,
-	);
+    renderer.fill_quad(
+        Quad {
+            bounds: layout.bounds(),
+            border: Border {
+                color: Color::from_rgb(0.6, 0.93, 1.0),
+                width: 1.0,
+                radius: 10.0.into(),
+            },
+            shadow: Shadow::default(),
+        },
+        Color::from_rgb(0.0, 0.33, 0.4),
+    );
+
+    self.inner_widget.as_widget().draw(
+        &state.children[0],
+        renderer,
+        theme,
+        style,
+        layout.children().next().unwrap(),
+        cursor,
+        viewport,
+    );
 }
 ```
 
@@ -95,7 +95,7 @@ fn children(&self) -> Vec<Tree> {
 }
 
 fn diff(&self, tree: &mut Tree) {
-	tree.diff_children(std::slice::from_ref(&self.inner_widget));
+    tree.diff_children(std::slice::from_ref(&self.inner_widget));
 }
 ```
 
@@ -132,7 +132,7 @@ impl Sandbox for MyApp {
 
     fn update(&mut self, _message: Self::Message) {}
 
-    fn view(&self) -> iced::Element<'_, Self::Message> {
+    fn view(&self) -> iced::Element<Self::Message> {
         container(MyWidgetOuter::new(button("Other widget").into()))
             .width(Length::Fill)
             .height(Length::Fill)

--- a/tutorial/text.md
+++ b/tutorial/text.md
@@ -32,7 +32,7 @@ impl Sandbox for MyApp {
 
     fn update(&mut self, _message: Self::Message) {}
 
-    fn view(&self) -> iced::Element<'_, Self::Message> {
+    fn view(&self) -> iced::Element<Self::Message> {
         column![
             "Construct from &str",
             text("Construct from function"),

--- a/tutorial/text_input.md
+++ b/tutorial/text_input.md
@@ -80,7 +80,7 @@ impl Sandbox for MyApp {
         }
     }
 
-    fn view(&self) -> iced::Element<'_, Self::Message> {
+    fn view(&self) -> iced::Element<Self::Message> {
         column![
             text_input("Construct from function", ""),
             TextInput::new("Construct from struct", ""),

--- a/tutorial/texts_in_widgets.md
+++ b/tutorial/texts_in_widgets.md
@@ -1,5 +1,7 @@
 # Texts In Widgets
 
+(This page of tutorial does not work. We are trying to fix it.)
+
 In addition to draw a [Quad](https://docs.rs/iced/latest/iced/advanced/renderer/struct.Quad.html), we can also draw texts in our widgets.
 
 For example, suppose we would like to draw a string slice named `CONTENT`.

--- a/tutorial/toggler.md
+++ b/tutorial/toggler.md
@@ -50,7 +50,7 @@ impl Sandbox for MyApp {
         }
     }
 
-    fn view(&self) -> iced::Element<'_, Self::Message> {
+    fn view(&self) -> iced::Element<Self::Message> {
         column![
             Toggler::new(Some("Construct from struct".into()), false, |_| {
                 MyAppMessage::DoNothing

--- a/tutorial/tooltip.md
+++ b/tutorial/tooltip.md
@@ -32,7 +32,7 @@ impl Sandbox for MyApp {
 
     fn update(&mut self, _message: Self::Message) {}
 
-    fn view(&self) -> iced::Element<'_, Self::Message> {
+    fn view(&self) -> iced::Element<Self::Message> {
         column![
             Tooltip::new(
                 button("Mouseover to see the tooltip"),

--- a/tutorial/updating_widgets_from_events.md
+++ b/tutorial/updating_widgets_from_events.md
@@ -18,8 +18,8 @@ fn on_event(
     _viewport: &Rectangle,
 ) -> event::Status {
     match event {
-		Event::Keyboard(keyboard::Event::KeyPressed {
-			key: keyboard::Key::Named(Named::Space),
+        Event::Keyboard(keyboard::Event::KeyPressed {
+            key: keyboard::Key::Named(Named::Space),
             ..
         }) => {
             self.highlight = !self.highlight;
@@ -84,7 +84,7 @@ impl Sandbox for MyApp {
 
     fn update(&mut self, _message: Self::Message) {}
 
-    fn view(&self) -> iced::Element<'_, Self::Message> {
+    fn view(&self) -> iced::Element<Self::Message> {
         container(MyWidget::new())
             .width(Length::Fill)
             .height(Length::Fill)

--- a/tutorial/updating_widgets_from_outside.md
+++ b/tutorial/updating_widgets_from_outside.md
@@ -24,18 +24,18 @@ fn draw(
     renderer.fill_quad(
         Quad {
             bounds: layout.bounds(),
-			border: Border {
-				color: Color::from_rgb(0.6, 0.8, 1.0),
-				width: 1.0,
-				radius: 10.0.into(),
-				},
-			shadow: Shadow::default(),
-		},
-		if self.highlight {
-			Color::from_rgb(0.6, 0.8, 1.0)
-		} else {
-			Color::from_rgb(0.0, 0.2, 0.4)
-		},
+            border: Border {
+                color: Color::from_rgb(0.6, 0.8, 1.0),
+                width: 1.0,
+                radius: 10.0.into(),
+            },
+            shadow: Shadow::default(),
+        },
+        if self.highlight {
+            Color::from_rgb(0.6, 0.8, 1.0)
+        } else {
+            Color::from_rgb(0.0, 0.2, 0.4)
+        },
     );
 }
 ```
@@ -98,6 +98,7 @@ fn main() -> iced::Result {
 enum MyMessage {
     Highlight(bool),
 }
+
 struct MyApp {
     highlight: bool,
 }
@@ -119,7 +120,7 @@ impl Sandbox for MyApp {
         }
     }
 
-    fn view(&self) -> iced::Element<'_, Self::Message> {
+    fn view(&self) -> iced::Element<Self::Message> {
         container(
             column![
                 MyWidget::new(self.highlight),

--- a/tutorial/widgets_with_children.md
+++ b/tutorial/widgets_with_children.md
@@ -130,7 +130,7 @@ impl Sandbox for MyApp {
 
     fn update(&mut self, _message: Self::Message) {}
 
-    fn view(&self) -> iced::Element<'_, Self::Message> {
+    fn view(&self) -> iced::Element<Self::Message> {
         container(MyWidgetOuter::new())
             .width(Length::Fill)
             .height(Length::Fill)

--- a/tutorial/width_and_height.md
+++ b/tutorial/width_and_height.md
@@ -34,7 +34,7 @@ impl Sandbox for MyApp {
 
     fn update(&mut self, _message: Self::Message) {}
 
-    fn view(&self) -> iced::Element<'_, Self::Message> {
+    fn view(&self) -> iced::Element<Self::Message> {
         column![
             button("Shrink").width(Length::Shrink),
             button("Fill").width(Length::Fill),


### PR DESCRIPTION
This pull request updates the signature of the view method to:
```rust
fn view(&self) -> iced::Element<Self::Message>
```
This makes the signature simpler and clearer.

The pull request also fixed the compiler error of Executing Custom Commands.