### PR TITLE
add correct code to dispatching_task_at_start

### DIFF
--- a/tutorial/dispatching_tasks_at_startup.md
+++ b/tutorial/dispatching_tasks_at_startup.md
@@ -12,19 +12,20 @@ To keep things aligned with the previous example, in the example below, we dispa
 
 ```rust
 use iced::{
-    Task,
-    widget::{button, column, text_input},
+    Task, Theme,
+    widget::{column, text_input},
 };
 
 fn main() -> iced::Result {
-    iced::run("My App", MyApp::update, MyApp::view)
+    iced::application("My App", MyApp::update, MyApp::view)
+        .theme(|_| Theme::TokyoNight)
+        .run_with(MyApp::new)
 }
 
 const MY_TEXT_ID: &str = "my_text";
 
 #[derive(Debug, Clone)]
 enum Message {
-    EditText,
     UpdateText(String),
 }
 
@@ -34,9 +35,15 @@ struct MyApp {
 }
 
 impl MyApp {
+    fn new() -> (Self, Task<Message>) {
+        let app = Self::default();
+        (app, text_input::focus(text_input::Id::new(MY_TEXT_ID)))
+        // Try returning (app, Task::none()) instead and see what happens
+        // (app, Task::none())
+    }
+
     fn update(&mut self, message: Message) -> Task<Message> {
         match message {
-            Message::EditText => return text_input::focus(text_input::Id::new(MY_TEXT_ID)),
             Message::UpdateText(s) => self.some_text = s,
         }
         Task::none()
@@ -44,7 +51,6 @@ impl MyApp {
 
     fn view(&self) -> iced::Element<Message> {
         column![
-            button("Edit text").on_press(Message::EditText),
             text_input("", &self.some_text)
                 .id(text_input::Id::new(MY_TEXT_ID))
                 .on_input(Message::UpdateText),


### PR DESCRIPTION
The code block in the chapter "Dispatching Tasks at Startup" is the same as the chapter before and does not use the iced::application to run the app. 