### PR TITLE
Update TOC to reflect removal of Sandbox trait

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,8 @@ For older Iced versions, please refer to the following branches:
 
 - [Setting Up](./tutorial/setting_up.md)
 - [First App - Hello World!](./tutorial/first_app.md)
-- [Explanation of Sandbox Trait](./tutorial/explanation_of_sandbox_trait.md)
+- [Explanation of the App Structure](./tutorial/explanation_of_app_structure.md)
+- [Application Lifecycle](./tutorial/application_lifecycle.md)
 - [Adding Widgets](./tutorial/adding_widgets.md)
 - [Changing Displaying Content](./tutorial/changing_displaying_content.md)
 - [Widgets](./tutorial/widgets.md)


### PR DESCRIPTION
Modify the list of links in the TOC to match the changes in the tutorial structure after the removal of the Sandbox trait in Iced 0.13.